### PR TITLE
Fix namespaces

### DIFF
--- a/Assets/GUIUtils/Attributes/AnimationCurveHeightAttribute.cs
+++ b/Assets/GUIUtils/Attributes/AnimationCurveHeightAttribute.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Diagnostics;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
     [Conditional("UNITY_EDITOR")]

--- a/Assets/GUIUtils/Attributes/AssignableTypeFilterAttribute.cs
+++ b/Assets/GUIUtils/Attributes/AssignableTypeFilterAttribute.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Diagnostics;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [AttributeUsage(AttributeTargets.All)]
     [Conditional("UNITY_EDITOR")]

--- a/Assets/GUIUtils/Attributes/BoldLabelAttribute.cs
+++ b/Assets/GUIUtils/Attributes/BoldLabelAttribute.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     public class BoldLabelAttribute : Attribute
     {

--- a/Assets/GUIUtils/Attributes/CombinedAttributes.cs
+++ b/Assets/GUIUtils/Attributes/CombinedAttributes.cs
@@ -1,7 +1,7 @@
 using System;
 using Sirenix.OdinInspector;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     // Note: IncludeMyAttributes will NOT work on classes
     [IncludeMyAttributes]

--- a/Assets/GUIUtils/Attributes/DrawAsUnityObjectAttribute.cs
+++ b/Assets/GUIUtils/Attributes/DrawAsUnityObjectAttribute.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Diagnostics;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
     [Conditional("UNITY_EDITOR")]

--- a/Assets/GUIUtils/Attributes/EditableLabelAttribute.cs
+++ b/Assets/GUIUtils/Attributes/EditableLabelAttribute.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Diagnostics;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [AttributeUsage(AttributeTargets.All)]
     [Conditional("UNITY_EDITOR")]

--- a/Assets/GUIUtils/Attributes/FittedLabelAttribute.cs
+++ b/Assets/GUIUtils/Attributes/FittedLabelAttribute.cs
@@ -2,7 +2,7 @@ using System;
 using System.Diagnostics;
 using Sirenix.OdinInspector;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [DontApplyToListElements]
     [AttributeUsage(AttributeTargets.All, AllowMultiple = false, Inherited = true)]

--- a/Assets/GUIUtils/Attributes/FoldoutContainerAttribute.cs
+++ b/Assets/GUIUtils/Attributes/FoldoutContainerAttribute.cs
@@ -2,7 +2,7 @@
 using System.Diagnostics;
 using Sirenix.OdinInspector;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = true)]
     [Conditional("UNITY_EDITOR")]

--- a/Assets/GUIUtils/Attributes/GenericValueAttribute.cs
+++ b/Assets/GUIUtils/Attributes/GenericValueAttribute.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     public class GenericValueAttribute : Attribute
     {

--- a/Assets/GUIUtils/Attributes/HideIfNullAttribute.cs
+++ b/Assets/GUIUtils/Attributes/HideIfNullAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Sirenix.OdinInspector;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = true)]
     [IncludeMyAttributes]

--- a/Assets/GUIUtils/Attributes/IconToggleAttribute.cs
+++ b/Assets/GUIUtils/Attributes/IconToggleAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
     [Conditional("UNITY_EDITOR")]

--- a/Assets/GUIUtils/Attributes/IgnoreInScriptableObjectCreatorAttribute.cs
+++ b/Assets/GUIUtils/Attributes/IgnoreInScriptableObjectCreatorAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [AttributeUsage(AttributeTargets.Class, Inherited = false)]
     [Conditional("UNITY_EDITOR")]

--- a/Assets/GUIUtils/Attributes/InlineEditorIconAttribute.cs
+++ b/Assets/GUIUtils/Attributes/InlineEditorIconAttribute.cs
@@ -2,7 +2,7 @@ using System;
 using System.Diagnostics;
 using Sirenix.OdinInspector;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [DontApplyToListElements]
     [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = true)]

--- a/Assets/GUIUtils/Attributes/InlineErrorAttribute.cs
+++ b/Assets/GUIUtils/Attributes/InlineErrorAttribute.cs
@@ -2,7 +2,7 @@
 using System.Diagnostics;
 using Sirenix.OdinInspector;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [DontApplyToListElements]
     [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = true)]

--- a/Assets/GUIUtils/Attributes/InlineIconButtonAttribute.cs
+++ b/Assets/GUIUtils/Attributes/InlineIconButtonAttribute.cs
@@ -2,7 +2,7 @@
 using System.Diagnostics;
 using Sirenix.OdinInspector;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [DontApplyToListElements]
     [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]

--- a/Assets/GUIUtils/Attributes/InlinePropertyAltAttribute.cs
+++ b/Assets/GUIUtils/Attributes/InlinePropertyAltAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [AttributeUsage(AttributeTargets.All, Inherited = false)]
     [Conditional("UNITY_EDITOR")]

--- a/Assets/GUIUtils/Attributes/InlineWarningAttribute.cs
+++ b/Assets/GUIUtils/Attributes/InlineWarningAttribute.cs
@@ -2,7 +2,7 @@
 using System.Diagnostics;
 using Sirenix.OdinInspector;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [DontApplyToListElements]
     [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = true)]

--- a/Assets/GUIUtils/Attributes/LayerAttribute.cs
+++ b/Assets/GUIUtils/Attributes/LayerAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
     [Conditional("UNITY_EDITOR")]

--- a/Assets/GUIUtils/Attributes/ListItemSelectorAttribute.cs
+++ b/Assets/GUIUtils/Attributes/ListItemSelectorAttribute.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 using UnityEditor;
 #endif
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [Conditional("UNITY_EDITOR")]
     public class ListItemSelectorAttribute : Attribute

--- a/Assets/GUIUtils/Attributes/OptionalValueAttribute.cs
+++ b/Assets/GUIUtils/Attributes/OptionalValueAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [AttributeUsage(AttributeTargets.All, AllowMultiple = false, Inherited = true)]
     [Conditional("UNITY_EDITOR")]

--- a/Assets/GUIUtils/Attributes/OrderRelativeToAttribute.cs
+++ b/Assets/GUIUtils/Attributes/OrderRelativeToAttribute.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 using Sirenix.OdinInspector;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [AttributeUsage(AttributeTargets.Property, Inherited = true)]
     [Conditional("UNITY_EDITOR")]

--- a/Assets/GUIUtils/Attributes/OverrideGroupAttribute.cs
+++ b/Assets/GUIUtils/Attributes/OverrideGroupAttribute.cs
@@ -2,7 +2,7 @@ using System;
 using System.Diagnostics;
 using Sirenix.OdinInspector;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = true, Inherited = true)]
     [Conditional("UNITY_EDITOR")]

--- a/Assets/GUIUtils/Attributes/PageSliderAttribute.cs
+++ b/Assets/GUIUtils/Attributes/PageSliderAttribute.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 using Sirenix.OdinInspector;
 
 // [assembly:OdinRegisterAttribute(typeof(PageSliderAttribute), "Custom", "Test")]
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = true)]
     [Conditional("UNITY_EDITOR"), DontApplyToListElements]

--- a/Assets/GUIUtils/Attributes/PropertiesGroupAttribute.cs
+++ b/Assets/GUIUtils/Attributes/PropertiesGroupAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using Sirenix.OdinInspector;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     public class PropertiesGroupAttribute : PropertyGroupAttribute
     {

--- a/Assets/GUIUtils/Attributes/ProtectedEditableAttribute.cs
+++ b/Assets/GUIUtils/Attributes/ProtectedEditableAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     public class ProtectedEditableAttribute : Attribute
     {

--- a/Assets/GUIUtils/Attributes/SearchPropertyAttribute.cs
+++ b/Assets/GUIUtils/Attributes/SearchPropertyAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter)]
     [Conditional("UNITY_EDITOR")]

--- a/Assets/GUIUtils/Attributes/ShaderParameterSelectorAttribute.cs
+++ b/Assets/GUIUtils/Attributes/ShaderParameterSelectorAttribute.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     public enum ShaderParameterType
     {

--- a/Assets/GUIUtils/Attributes/TagSelectorAttribute.cs
+++ b/Assets/GUIUtils/Attributes/TagSelectorAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [AttributeUsage(AttributeTargets.All)]
     [Conditional("UNITY_EDITOR")]

--- a/Assets/GUIUtils/Attributes/TitleAttributes.cs
+++ b/Assets/GUIUtils/Attributes/TitleAttributes.cs
@@ -1,7 +1,7 @@
 using System;
 using Sirenix.OdinInspector;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [IncludeMyAttributes]
     [DontApplyToListElements]

--- a/Assets/GUIUtils/Attributes/ToggleButtonAttribute.cs
+++ b/Assets/GUIUtils/Attributes/ToggleButtonAttribute.cs
@@ -2,7 +2,7 @@
 using System.Diagnostics;
 using Sirenix.OdinInspector;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
     [Conditional("UNITY_EDITOR")]

--- a/Assets/GUIUtils/Attributes/ToggleButtonOppositeAttribute.cs
+++ b/Assets/GUIUtils/Attributes/ToggleButtonOppositeAttribute.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Diagnostics;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
     [Conditional("UNITY_EDITOR")]

--- a/Assets/GUIUtils/Attributes/ToggledByAttribute.cs
+++ b/Assets/GUIUtils/Attributes/ToggledByAttribute.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     public class ToggledByAttribute : Attribute
     {

--- a/Assets/GUIUtils/Attributes/UnfoldListAttribute.cs
+++ b/Assets/GUIUtils/Attributes/UnfoldListAttribute.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 using Sirenix.OdinInspector;
 #endif
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Attributes
 {
     /// <summary>
     /// Simply displays a list within a box; Has no drag, add, remove, foldout or paging functionality.

--- a/Assets/GUIUtils/Editor/GUI/EditorExtendor.cs
+++ b/Assets/GUIUtils/Editor/GUI/EditorExtendor.cs
@@ -36,7 +36,7 @@ namespace Rhinox.GUIUtils.Editor
         // public Type m_InspectorType;
         private static FieldInfo _inspectorTypeField;
 
-        private static bool _typesProcessed;
+        private static bool _typesProcessed; // TODO: what is this for?
 
 #if !ODIN_INSPECTOR // OdinEditor implements these, to allow easy override make stubs
     protected virtual void OnEnable() { }

--- a/Assets/GUIUtils/Editor/Windows/InputDialog/DialogData.cs
+++ b/Assets/GUIUtils/Editor/Windows/InputDialog/DialogData.cs
@@ -7,27 +7,29 @@ using UnityEngine;
 using Sirenix.OdinInspector;
 #endif
 
-public class DialogBuilder
+namespace Rhinox.GUIUtils.Editor
 {
-    public abstract class ValueReference<T>
+    public class DialogBuilder
     {
-        public abstract T Value { get; }
-        
-        public static implicit operator T(ValueReference<T> reference) => reference.Value;
-    }
-
-    public class FieldWrapper<T> : ValueReference<T>
-    {
-        public DialogInputField<T> Field;
-        
-        public FieldWrapper(DialogInputField<T> field)
+        public abstract class ValueReference<T>
         {
-            Field = field;
+            public abstract T Value { get; }
+
+            public static implicit operator T(ValueReference<T> reference) => reference.Value;
         }
 
-        public override T Value => Field.SmartValue;
-    }
-    
+        public class FieldWrapper<T> : ValueReference<T>
+        {
+            public DialogInputField<T> Field;
+
+            public FieldWrapper(DialogInputField<T> field)
+            {
+                Field = field;
+            }
+
+            public override T Value => Field.SmartValue;
+        }
+
 #if ODIN_INSPECTOR
     public class ValueDropdownItemWrapper<T> : ValueReference<T>
     {
@@ -41,74 +43,83 @@ public class DialogBuilder
         public override T Value => Field.SmartValue.Value;
     }
 #endif
-    
-    private DialogData _dialogData;
 
-    public DialogBuilder(string title, string content, string confirm = "Confirm", string cancel = "Cancel")
-    {
-        _dialogData = new DialogData(title, content, confirm, cancel);
-    }
+        private DialogData _dialogData;
 
-    public void ConfirmMessage(string confirm) => _dialogData.ConfirmButton = confirm;
-    public void CancelMessage(string cancel) => _dialogData.CancelButton = cancel;
+        public DialogBuilder(string title, string content, string confirm = "Confirm", string cancel = "Cancel")
+        {
+            _dialogData = new DialogData(title, content, confirm, cancel);
+        }
 
-    private DialogBuilder Add<T, TValue>(T field, out ValueReference<TValue> reference, TValue initialValue)
-        where T : DialogInputField<TValue>
-    {
-        reference = new FieldWrapper<TValue>( _dialogData.Add(field, initialValue) );
-        return this;
-    }
-    
-    public DialogBuilder BooleanField(string name, out ValueReference<bool> reference, bool initialValue = default, string tooltip = null)
-    {
-        var field = new BoolInputField(name, tooltip);
-        return Add(field, out reference, initialValue);
-    }
-    
-    public DialogBuilder IntField(string name, out ValueReference<int> reference, int initialValue = default, string tooltip = null)
-    {
-        var field = new Int32InputField(name, tooltip);
-        return Add(field, out reference, initialValue);
-    }
+        public void ConfirmMessage(string confirm) => _dialogData.ConfirmButton = confirm;
+        public void CancelMessage(string cancel) => _dialogData.CancelButton = cancel;
 
-    public DialogBuilder FloatField(string name, out ValueReference<float> reference, float initialValue = default, string tooltip = null)
-    {
-        var field = new FloatInputField(name, tooltip);
-        return Add(field, out reference, initialValue);
-    }
-    
-    public DialogBuilder TextField(string name, out ValueReference<string> reference, string initialValue = "", string tooltip = null)
-    {
-        var field = new TextInputField(name, tooltip);
-        return Add(field, out reference, initialValue);
-    }
+        private DialogBuilder Add<T, TValue>(T field, out ValueReference<TValue> reference, TValue initialValue)
+            where T : DialogInputField<TValue>
+        {
+            reference = new FieldWrapper<TValue>(_dialogData.Add(field, initialValue));
+            return this;
+        }
 
-    public DialogBuilder TransformField(string name, out ValueReference<Transform> reference, Transform initialValue = null, string tooltip = null)
-    {
-        var field = new TransformInputField(name, tooltip);
-        return Add(field, out reference, initialValue);
-    }
-    
-    public DialogBuilder GameObjectField(string name, out ValueReference<GameObject> reference, GameObject initialValue = null, string tooltip = null)
-    {
-        var field = new GameObjectInputField(name, tooltip);
-        return Add(field, out reference, initialValue);
-    }
-    
-    public DialogBuilder MaterialField(string name, out ValueReference<Material> reference, Material initialValue = null, string tooltip = null)
-    {
-        var field = new MaterialInputField(name, tooltip);
-        return Add(field, out reference, initialValue);
-    }
-    
-    public DialogBuilder TextureField(string name, out ValueReference<Texture> reference, Texture initialValue = null, string tooltip = null)
-    {
-        var field = new TextureInputField(name, tooltip);
-        return Add(field, out reference, initialValue);
-    }
+        public DialogBuilder BooleanField(string name, out ValueReference<bool> reference, bool initialValue = default,
+            string tooltip = null)
+        {
+            var field = new BoolInputField(name, tooltip);
+            return Add(field, out reference, initialValue);
+        }
+
+        public DialogBuilder IntField(string name, out ValueReference<int> reference, int initialValue = default,
+            string tooltip = null)
+        {
+            var field = new Int32InputField(name, tooltip);
+            return Add(field, out reference, initialValue);
+        }
+
+        public DialogBuilder FloatField(string name, out ValueReference<float> reference, float initialValue = default,
+            string tooltip = null)
+        {
+            var field = new FloatInputField(name, tooltip);
+            return Add(field, out reference, initialValue);
+        }
+
+        public DialogBuilder TextField(string name, out ValueReference<string> reference, string initialValue = "",
+            string tooltip = null)
+        {
+            var field = new TextInputField(name, tooltip);
+            return Add(field, out reference, initialValue);
+        }
+
+        public DialogBuilder TransformField(string name, out ValueReference<Transform> reference,
+            Transform initialValue = null, string tooltip = null)
+        {
+            var field = new TransformInputField(name, tooltip);
+            return Add(field, out reference, initialValue);
+        }
+
+        public DialogBuilder GameObjectField(string name, out ValueReference<GameObject> reference,
+            GameObject initialValue = null, string tooltip = null)
+        {
+            var field = new GameObjectInputField(name, tooltip);
+            return Add(field, out reference, initialValue);
+        }
+
+        public DialogBuilder MaterialField(string name, out ValueReference<Material> reference,
+            Material initialValue = null, string tooltip = null)
+        {
+            var field = new MaterialInputField(name, tooltip);
+            return Add(field, out reference, initialValue);
+        }
+
+        public DialogBuilder TextureField(string name, out ValueReference<Texture> reference,
+            Texture initialValue = null, string tooltip = null)
+        {
+            var field = new TextureInputField(name, tooltip);
+            return Add(field, out reference, initialValue);
+        }
 
 #if ODIN_INSPECTOR
-    public DialogBuilder Dropdown<T>(string name, ICollection<T> options, Func<T, string> nameSelector, out ValueReference<T> reference, T initialValue = default, string tooltip = null)
+    public DialogBuilder Dropdown<T>(string name, ICollection<T> options, Func<T, string> nameSelector, out ValueReference<T> reference, T initialValue
+ = default, string tooltip = null)
     {
         var valueOptions = new ValueDropdownList<T>();
         foreach (var val in options)
@@ -116,7 +127,8 @@ public class DialogBuilder
         return Dropdown(name, valueOptions, out reference, initialValue, tooltip);
     }
     
-    public DialogBuilder Dropdown<T>(string name, ICollection<ValueDropdownItem<T>> options, out ValueReference<T> reference, ValueDropdownItem<T> initialValue = default, string tooltip = null)
+    public DialogBuilder Dropdown<T>(string name, ICollection<ValueDropdownItem<T>> options, out ValueReference<T> reference, ValueDropdownItem<T> initialValue
+ = default, string tooltip = null)
     {
         var field = new DropdownInputField<T>(name, options, tooltip);
         _dialogData.Add(field, initialValue);
@@ -124,105 +136,109 @@ public class DialogBuilder
         return this;
     }
     
-    public DialogBuilder Dropdown<T>(string name, ICollection<ValueDropdownItem<T>> options, out ValueReference<T> reference, T initialValue, string tooltip = null)
+    public DialogBuilder Dropdown<T>(string name, ICollection<ValueDropdownItem<T>> options, out ValueReference<T> reference, T initialValue, string tooltip
+ = null)
     {
         var initialPick = options.FirstOrDefault(x => Equals(x.Value, initialValue));
         return Dropdown(name, options, out reference, initialPick, tooltip);
     }
     
-    public DialogBuilder Dropdown(string name, ICollection<ValueDropdownItem> options, out ValueReference<ValueDropdownItem> reference, ValueDropdownItem initialValue = default, string tooltip = null)
+    public DialogBuilder Dropdown(string name, ICollection<ValueDropdownItem> options, out ValueReference<ValueDropdownItem> reference, ValueDropdownItem initialValue
+ = default, string tooltip = null)
     {
         var field = new DropdownInputField(name, options, tooltip);
         return Add(field, out reference, initialValue);
     }
 #endif
-    
-    public DialogBuilder OnAccept(Action action)
-    {
-        _dialogData.Accepted += action;
-        return this;
-    }
-    
-    public DialogBuilder OnCancel(Action action)
-    {
-        _dialogData.Canceled += action;
-        return this;
-    }
-    
-    public EditorInputDialog Show()
-    {
-        return EditorInputDialog.ShowDialog(_dialogData);
-    }
-    
-    public EditorInputDialog ShowInPopup()
-    {
-        return EditorInputDialog.ShowInPopup(_dialogData);
-    }
-    
-    public EditorInputDialog ShowBlocking()
-    {
-        return EditorInputDialog.ShowBlocking(_dialogData);
-    }
 
-}
+        public DialogBuilder OnAccept(Action action)
+        {
+            _dialogData.Accepted += action;
+            return this;
+        }
 
+        public DialogBuilder OnCancel(Action action)
+        {
+            _dialogData.Canceled += action;
+            return this;
+        }
 
+        public EditorInputDialog Show()
+        {
+            return EditorInputDialog.ShowDialog(_dialogData);
+        }
 
-public class DialogData
-{
-    public string Title;
-    public string Content;
-    public string ConfirmButton;
-    public string CancelButton;
+        public EditorInputDialog ShowInPopup()
+        {
+            return EditorInputDialog.ShowInPopup(_dialogData);
+        }
 
-    private List<DialogInputField> _fields;
+        public EditorInputDialog ShowBlocking()
+        {
+            return EditorInputDialog.ShowBlocking(_dialogData);
+        }
 
-    public event Action Accepted;
-    public event Action Canceled;
-
-    public IReadOnlyList<DialogInputField> Fields => _fields.AsReadOnly();
-
-    private DialogData()
-    {
-        _fields = new List<DialogInputField>();
-    }
-    
-    public DialogData(string title, string content, string confirm = "Confirm", string cancel = "Cancel")
-        : this()
-    {
-        Title = title;
-        Content = content;
-        ConfirmButton = confirm;
-        CancelButton = cancel;
     }
 
-    public DialogInputField<T> Add<T>(DialogInputField<T> field, T initialValue = default)
-    {
-        field.SmartValue = initialValue;
-        _fields.Add(field);
-        return field;
-    }
 
-    public void Resolve(bool accepted)
-    {
-        if (accepted)
-            Accepted?.Invoke();
-        else
-            Canceled?.Invoke();
-    }
 
-    public int GetPreferredWidth()
+    public class DialogData
     {
-        int width = 0;
-        foreach (var field in Fields)
-            width = Math.Max(field.GetWidth(), width);
-        return width;
-    }
-    
-    public int GetPreferredHeight() => 60 + (Fields.Sum(x => x.Height));
+        public string Title;
+        public string Content;
+        public string ConfirmButton;
+        public string CancelButton;
 
-    public static DialogBuilder Create(string title, string content, string confirm = "Confirm", string cancel = "Cancel")
-    {
-        return new DialogBuilder(title, content, confirm, cancel);
+        private List<DialogInputField> _fields;
+
+        public event Action Accepted;
+        public event Action Canceled;
+
+        public IReadOnlyList<DialogInputField> Fields => _fields.AsReadOnly();
+
+        private DialogData()
+        {
+            _fields = new List<DialogInputField>();
+        }
+
+        public DialogData(string title, string content, string confirm = "Confirm", string cancel = "Cancel")
+            : this()
+        {
+            Title = title;
+            Content = content;
+            ConfirmButton = confirm;
+            CancelButton = cancel;
+        }
+
+        public DialogInputField<T> Add<T>(DialogInputField<T> field, T initialValue = default)
+        {
+            field.SmartValue = initialValue;
+            _fields.Add(field);
+            return field;
+        }
+
+        public void Resolve(bool accepted)
+        {
+            if (accepted)
+                Accepted?.Invoke();
+            else
+                Canceled?.Invoke();
+        }
+
+        public int GetPreferredWidth()
+        {
+            int width = 0;
+            foreach (var field in Fields)
+                width = Math.Max(field.GetWidth(), width);
+            return width;
+        }
+
+        public int GetPreferredHeight() => 60 + (Fields.Sum(x => x.Height));
+
+        public static DialogBuilder Create(string title, string content, string confirm = "Confirm",
+            string cancel = "Cancel")
+        {
+            return new DialogBuilder(title, content, confirm, cancel);
+        }
     }
 }

--- a/Assets/GUIUtils/Editor/Windows/InputDialog/DialogInputField.cs
+++ b/Assets/GUIUtils/Editor/Windows/InputDialog/DialogInputField.cs
@@ -1,76 +1,79 @@
 using UnityEditor;
 using UnityEngine;
 
-public abstract class DialogInputField
+namespace Rhinox.GUIUtils.Editor
 {
-    protected GUIContent _label;
-    public GUIContent Label => _label;
-
-    public abstract object WeakValue { get; }
-    public int Height { get; protected set; } = 22;
-
-    public delegate void InputFieldHandler(DialogInputField field);
-
-    public event InputFieldHandler ValidateValue;
-    public event InputFieldHandler ValueChanged;
-
-    public void Draw(GUIContent label)
+    public abstract class DialogInputField
     {
-        DrawField(label ?? Label);
-    }
-    
-    public virtual int GetWidth()
-    {
-        return 0;
-    }
-    
-    private void DrawField(GUIContent label)
-    {
-        var rect = EditorGUILayout.GetControlRect();
-        if (label != null)
+        protected GUIContent _label;
+        public GUIContent Label => _label;
+
+        public abstract object WeakValue { get; }
+        public int Height { get; protected set; } = 22;
+
+        public delegate void InputFieldHandler(DialogInputField field);
+
+        public event InputFieldHandler ValidateValue;
+        public event InputFieldHandler ValueChanged;
+
+        public void Draw(GUIContent label)
         {
-#if ODIN_INSPECTOR
-            var labelWidth = Sirenix.Utilities.Editor.GUIHelper.BetterLabelWidth;
-#else
-            var labelWidth = EditorGUIUtility.labelWidth;
-#endif
-            var labelRect = AlignLeft(rect, labelWidth);
-            var fieldRect = AlignRight(rect, rect.width - labelWidth);
-
-            EditorGUI.LabelField(labelRect, label);
-            DrawFieldValue(fieldRect);
+            DrawField(label ?? Label);
         }
-        else
-            DrawFieldValue(rect);
+
+        public virtual int GetWidth()
+        {
+            return 0;
+        }
+
+        private void DrawField(GUIContent label)
+        {
+            var rect = EditorGUILayout.GetControlRect();
+            if (label != null)
+            {
+#if ODIN_INSPECTOR
+                var labelWidth = Sirenix.Utilities.Editor.GUIHelper.BetterLabelWidth;
+#else
+                var labelWidth = EditorGUIUtility.labelWidth;
+#endif
+                var labelRect = AlignLeft(rect, labelWidth);
+                var fieldRect = AlignRight(rect, rect.width - labelWidth);
+
+                EditorGUI.LabelField(labelRect, label);
+                DrawFieldValue(fieldRect);
+            }
+            else
+                DrawFieldValue(rect);
+        }
+
+        public static Rect AlignLeft(Rect rect, float width)
+        {
+            rect.width = width;
+            return rect;
+        }
+
+        public static Rect AlignRight(Rect rect, float width)
+        {
+            rect.x = rect.x + rect.width - width;
+            rect.width = width;
+            return rect;
+        }
+
+        protected abstract void DrawFieldValue(Rect rect);
     }
-    
-    public static Rect AlignLeft(Rect rect, float width)
+
+    public abstract class DialogInputField<T> : DialogInputField
     {
-        rect.width = width;
-        return rect;
+        public T SmartValue;
+
+        public T Get() => SmartValue;
+
+        protected DialogInputField(string label, string tooltip = null, T initialValue = default(T))
+        {
+            _label = new GUIContent(label, tooltip);
+            SmartValue = initialValue;
+        }
+
+        public override object WeakValue => SmartValue;
     }
-    
-    public static Rect AlignRight(Rect rect, float width)
-    {
-        rect.x = rect.x + rect.width - width;
-        rect.width = width;
-        return rect;
-    }
-
-    protected abstract void DrawFieldValue(Rect rect);
-}
-
-public abstract class DialogInputField<T> : DialogInputField
-{
-    public T SmartValue;
-
-    public T Get() => SmartValue;
-
-    protected DialogInputField(string label, string tooltip = null, T initialValue = default(T))
-    {
-        _label = new GUIContent(label, tooltip);
-        SmartValue = initialValue;
-    }
-
-    public override object WeakValue => SmartValue;
 }

--- a/Assets/GUIUtils/Editor/Windows/InputDialog/DialogInputField.cs
+++ b/Assets/GUIUtils/Editor/Windows/InputDialog/DialogInputField.cs
@@ -13,8 +13,12 @@ namespace Rhinox.GUIUtils.Editor
 
         public delegate void InputFieldHandler(DialogInputField field);
 
+#pragma warning disable 67
+
         public event InputFieldHandler ValidateValue;
         public event InputFieldHandler ValueChanged;
+
+#pragma warning restore 67
 
         public void Draw(GUIContent label)
         {

--- a/Assets/GUIUtils/Editor/Windows/InputDialog/DropdownInputField.cs
+++ b/Assets/GUIUtils/Editor/Windows/InputDialog/DropdownInputField.cs
@@ -6,67 +6,72 @@ using Sirenix.OdinInspector.Editor;
 using UnityEditor;
 using UnityEngine;
 
-public class DropdownInputField : DialogInputField<ValueDropdownItem>
+namespace Rhinox.GUIUtils.Editor
 {
-    private ValueDropdownItem[] _options;
-    
-    public DropdownInputField(string label, IEnumerable<ValueDropdownItem> options, string tooltip = null, ValueDropdownItem initialValue = default)
-        : base(label, tooltip, initialValue)
+    public class DropdownInputField : DialogInputField<ValueDropdownItem>
     {
-        _options = options.ToArray();
-    }
-    
-    protected override void DrawFieldValue(Rect rect)
-    {
-        if (GUI.Button(rect, SmartValue.Text, EditorStyles.miniPullDown))
+        private ValueDropdownItem[] _options;
+
+        public DropdownInputField(string label, IEnumerable<ValueDropdownItem> options, string tooltip = null,
+            ValueDropdownItem initialValue = default)
+            : base(label, tooltip, initialValue)
         {
-            var selector = new GenericSelector<ValueDropdownItem>(_options) { FlattenedTree = true };
-            
-            selector.EnableSingleClickToSelect();
-            selector.SelectionConfirmed += x =>
-            {
-                var t = x.FirstOrDefault();
-                SmartValue = t;
-            };
-            
-            selector.ShowInPopup(rect);
+            _options = options.ToArray();
         }
-    }
 
-    public override int GetWidth()
-    {
-        return 200 + _options.Max(x => x.Text.Length) * 8;
-    }
-
-}
-
-public class DropdownInputField<T> : DialogInputField<ValueDropdownItem<T>>
-{
-    private ValueDropdownItem<T>[] _options;
-    
-    public DropdownInputField(string label, IEnumerable<ValueDropdownItem<T>> options, string tooltip = null, ValueDropdownItem<T> initialValue = default)
-        : base(label, tooltip, initialValue)
-    {
-        _options = options.ToArray();
-    }
-    
-    protected override void DrawFieldValue(Rect rect)
-    {
-        if (GUI.Button(rect, SmartValue.Text, EditorStyles.miniPullDown))
+        protected override void DrawFieldValue(Rect rect)
         {
-            var selector = new GenericSelector<ValueDropdownItem<T>>(_options) { FlattenedTree = true };
-            
-            selector.EnableSingleClickToSelect();
-            selector.SelectionConfirmed += x =>
+            if (GUI.Button(rect, SmartValue.Text, EditorStyles.miniPullDown))
             {
-                var t = x.FirstOrDefault();
-                SmartValue = t;
-            };
-            
-            selector.ShowInPopup(rect);
+                var selector = new GenericSelector<ValueDropdownItem>(_options) { FlattenedTree = true };
+
+                selector.EnableSingleClickToSelect();
+                selector.SelectionConfirmed += x =>
+                {
+                    var t = x.FirstOrDefault();
+                    SmartValue = t;
+                };
+
+                selector.ShowInPopup(rect);
+            }
         }
+
+        public override int GetWidth()
+        {
+            return 200 + _options.Max(x => x.Text.Length) * 8;
+        }
+
     }
 
+    public class DropdownInputField<T> : DialogInputField<ValueDropdownItem<T>>
+    {
+        private ValueDropdownItem<T>[] _options;
+
+        public DropdownInputField(string label, IEnumerable<ValueDropdownItem<T>> options, string tooltip = null,
+            ValueDropdownItem<T> initialValue = default)
+            : base(label, tooltip, initialValue)
+        {
+            _options = options.ToArray();
+        }
+
+        protected override void DrawFieldValue(Rect rect)
+        {
+            if (GUI.Button(rect, SmartValue.Text, EditorStyles.miniPullDown))
+            {
+                var selector = new GenericSelector<ValueDropdownItem<T>>(_options) { FlattenedTree = true };
+
+                selector.EnableSingleClickToSelect();
+                selector.SelectionConfirmed += x =>
+                {
+                    var t = x.FirstOrDefault();
+                    SmartValue = t;
+                };
+
+                selector.ShowInPopup(rect);
+            }
+        }
+
+    }
 }
 
 #endif

--- a/Assets/GUIUtils/Editor/Windows/InputDialog/EditorInputDialog.cs
+++ b/Assets/GUIUtils/Editor/Windows/InputDialog/EditorInputDialog.cs
@@ -4,168 +4,173 @@ using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 
-public class EditorInputDialog : EditorWindow
+namespace Rhinox.GUIUtils.Editor
 {
-    private DialogData _data;
-    
-    public int Width = 250;
-    
-    // Event.current is not available in a contextmenu function
-    // However, it is still available in the code
-    // So hack into it and fetch it... why unity (Only way to get mouse position)
-    private static FieldInfo _currentEventField = typeof(Event).GetField("s_Current", BindingFlags.Static | BindingFlags.NonPublic);
-
-    
-    private void OnGUI()
+    public class EditorInputDialog : EditorWindow
     {
-        if (_data == null)
+        private DialogData _data;
+
+        public int Width = 250;
+
+        // Event.current is not available in a contextmenu function
+        // However, it is still available in the code
+        // So hack into it and fetch it... why unity (Only way to get mouse position)
+        private static FieldInfo _currentEventField =
+            typeof(Event).GetField("s_Current", BindingFlags.Static | BindingFlags.NonPublic);
+
+
+        private void OnGUI()
         {
-            Close();
-            return;
+            if (_data == null)
+            {
+                Close();
+                return;
+            }
+
+            EditorGUILayout.BeginVertical(GUIStyle.none, GUILayout.ExpandHeight(true), GUILayout.ExpandWidth(true));
+            EditorGUILayout.LabelField(_data.Content);
+
+            foreach (var field in _data.Fields)
+                field.Draw(null);
+
+            GUILayout.FlexibleSpace();
+
+            var rect = EditorGUILayout.GetControlRect();
+            var confirmRect = AlignLeft(rect, rect.width * 0.48f);
+            var cancelRect = AlignRight(rect, rect.width * 0.48f);
+
+            if (GUI.Button(confirmRect, _data.ConfirmButton))
+            {
+                _data.Resolve(true);
+                Close();
+            }
+
+            if (GUI.Button(cancelRect, _data.CancelButton))
+            {
+                _data.Resolve(false);
+                Close();
+            }
+
+            EditorGUILayout.EndVertical();
         }
 
-        EditorGUILayout.BeginVertical(GUIStyle.none, GUILayout.ExpandHeight(true), GUILayout.ExpandWidth(true));
-        EditorGUILayout.LabelField(_data.Content);
-
-        foreach (var field in _data.Fields)
-            field.Draw(null);
-        
-        GUILayout.FlexibleSpace();
-
-        var rect = EditorGUILayout.GetControlRect();
-        var confirmRect = AlignLeft(rect, rect.width * 0.48f);
-        var cancelRect = AlignRight(rect, rect.width * 0.48f);
-
-        if (GUI.Button(confirmRect, _data.ConfirmButton))
+        public static Rect AlignLeft(Rect rect, float width)
         {
-            _data.Resolve(true);
-            Close();
+            rect.width = width;
+            return rect;
         }
 
-        if (GUI.Button(cancelRect, _data.CancelButton))
+        public static Rect AlignRight(Rect rect, float width)
         {
-            _data.Resolve(false);
-            Close();
+            rect.x = rect.x + rect.width - width;
+            rect.width = width;
+            return rect;
         }
-        
-        EditorGUILayout.EndVertical();
-    }
-    
-    public static Rect AlignLeft(Rect rect, float width)
-    {
-        rect.width = width;
-        return rect;
-    }
-    
-    public static Rect AlignRight(Rect rect, float width)
-    {
-        rect.x = rect.x + rect.width - width;
-        rect.width = width;
-        return rect;
-    }
 
-    public void SetData(DialogData data)
-    {
-        titleContent = new GUIContent(data.Title);
-        
-        _data = data;
-    }
-
-    public void Resize(int width)
-    {
-        float y = 60 + (_data.Fields.Sum(x => x.Height));
-        minSize = new Vector2(width, y);
-        maxSize = minSize;
-    }
-
-    public void CenterOn(EditorWindow win)
-    {
-        if (!win) return;
-        
-        var pos = position;
-        pos.center = win.position.center;
-        position = pos;
-    }
-
-    /// ================================================================================================================
-    /// BUILDER METHODS
-    public static DialogBuilder Create(string title, string content, string confirm = "Confirm", string cancel = "Cancel")
-    {
-        return new DialogBuilder(title, content, confirm, cancel);
-    }
-
-    public static EditorInputDialog ShowDialog(DialogData data)
-    {
-        var window = InitWindow(data, out int width);
-
-        window.Resize(width);
-        
-        var currentWindow = EditorWindow.focusedWindow;
-        
-        window.ShowUtility();
-        
-        window.CenterOn(currentWindow);
-        return window;
-    }
-    
-    public static EditorInputDialog ShowOnWindow(DialogData data, Vector2? openPosition = null)
-    {
-        if (!openPosition.HasValue)
+        public void SetData(DialogData data)
         {
+            titleContent = new GUIContent(data.Title);
+
+            _data = data;
+        }
+
+        public void Resize(int width)
+        {
+            float y = 60 + (_data.Fields.Sum(x => x.Height));
+            minSize = new Vector2(width, y);
+            maxSize = minSize;
+        }
+
+        public void CenterOn(EditorWindow win)
+        {
+            if (!win) return;
+
+            var pos = position;
+            pos.center = win.position.center;
+            position = pos;
+        }
+
+        /// ================================================================================================================
+        /// BUILDER METHODS
+        public static DialogBuilder Create(string title, string content, string confirm = "Confirm",
+            string cancel = "Cancel")
+        {
+            return new DialogBuilder(title, content, confirm, cancel);
+        }
+
+        public static EditorInputDialog ShowDialog(DialogData data)
+        {
+            var window = InitWindow(data, out int width);
+
+            window.Resize(width);
+
             var currentWindow = EditorWindow.focusedWindow;
-            openPosition = currentWindow.position.center;
+
+            window.ShowUtility();
+
+            window.CenterOn(currentWindow);
+            return window;
         }
 
-        return ShowInPopup(data, openPosition);
-    }
-    
-    public static EditorInputDialog ShowInPopup(DialogData data, Vector2? openPosition = null)
-    {
-        var window = InitWindow(data, out int x);
-        
-        int y = data.GetPreferredHeight();
-
-        if (!openPosition.HasValue)
+        public static EditorInputDialog ShowOnWindow(DialogData data, Vector2? openPosition = null)
         {
-            Event e = Event.current;
-            if (e == null) // See explanation @ _currentEventField
-                e = _currentEventField.GetValue(null) as Event;
-            
-            openPosition = e.mousePosition;
-            // this is the mousepos relative to the window; offset it
-            openPosition += EditorWindow.focusedWindow.position.position;
+            if (!openPosition.HasValue)
+            {
+                var currentWindow = EditorWindow.focusedWindow;
+                openPosition = currentWindow.position.center;
+            }
+
+            return ShowInPopup(data, openPosition);
         }
-        
-        // Use the given position or mouse position
-        Vector2 position = openPosition.Value;
-        Rect btnRect = new Rect(position.x, position.y, 1f, 1f); // Dummy rect
-        window.ShowAsDropDown(btnRect, new Vector2(x, y));
 
-        return window;
-    }
+        public static EditorInputDialog ShowInPopup(DialogData data, Vector2? openPosition = null)
+        {
+            var window = InitWindow(data, out int x);
 
-    public static EditorInputDialog ShowBlocking(DialogData data)
-    {
-        var window = InitWindow(data, out int width);
+            int y = data.GetPreferredHeight();
 
-        window.Resize(width);
-        
-        var currentWindow = EditorWindow.focusedWindow;
-        
-        window.ShowModal();
-        
-        window.CenterOn(currentWindow);
-        return window;
-    }
-    
-    private static EditorInputDialog InitWindow(DialogData data, out int width)
-    {
-        var window = CreateInstance<EditorInputDialog>();
-        
-        window.SetData(data);
-        
-        width = Mathf.Max(window.Width, data.GetPreferredWidth());
-        
-        return window;
+            if (!openPosition.HasValue)
+            {
+                Event e = Event.current;
+                if (e == null) // See explanation @ _currentEventField
+                    e = _currentEventField.GetValue(null) as Event;
+
+                openPosition = e.mousePosition;
+                // this is the mousepos relative to the window; offset it
+                openPosition += EditorWindow.focusedWindow.position.position;
+            }
+
+            // Use the given position or mouse position
+            Vector2 position = openPosition.Value;
+            Rect btnRect = new Rect(position.x, position.y, 1f, 1f); // Dummy rect
+            window.ShowAsDropDown(btnRect, new Vector2(x, y));
+
+            return window;
+        }
+
+        public static EditorInputDialog ShowBlocking(DialogData data)
+        {
+            var window = InitWindow(data, out int width);
+
+            window.Resize(width);
+
+            var currentWindow = EditorWindow.focusedWindow;
+
+            window.ShowModal();
+
+            window.CenterOn(currentWindow);
+            return window;
+        }
+
+        private static EditorInputDialog InitWindow(DialogData data, out int width)
+        {
+            var window = CreateInstance<EditorInputDialog>();
+
+            window.SetData(data);
+
+            width = Mathf.Max(window.Width, data.GetPreferredWidth());
+
+            return window;
+        }
     }
 }

--- a/Assets/GUIUtils/Editor/Windows/InputDialog/TextInputField.cs
+++ b/Assets/GUIUtils/Editor/Windows/InputDialog/TextInputField.cs
@@ -1,16 +1,18 @@
 using UnityEditor;
 using UnityEngine;
 
-public class TextInputField : DialogInputField<string>
+namespace Rhinox.GUIUtils.Editor
 {
-    public TextInputField(string label, string tooltip = null, string initialValue = default(string))
-        : base(label, tooltip, initialValue)
+    public class TextInputField : DialogInputField<string>
     {
-    }
-    
-    protected override void DrawFieldValue(Rect rect)
-    {
-        SmartValue = EditorGUI.TextField(rect, SmartValue);
-    }
+        public TextInputField(string label, string tooltip = null, string initialValue = default(string))
+            : base(label, tooltip, initialValue)
+        {
+        }
 
+        protected override void DrawFieldValue(Rect rect)
+        {
+            SmartValue = EditorGUI.TextField(rect, SmartValue);
+        }
+    }
 }

--- a/Assets/GUIUtils/Editor/Windows/InputDialog/ValueTypeInputFields.cs
+++ b/Assets/GUIUtils/Editor/Windows/InputDialog/ValueTypeInputFields.cs
@@ -1,42 +1,45 @@
 using UnityEditor;
 using UnityEngine;
 
-public class Int32InputField : DialogInputField<int>
+namespace Rhinox.GUIUtils.Editor
 {
-    public Int32InputField(string label, string tooltip = null, int initialValue = default(int))
-        : base(label, tooltip, initialValue)
+    public class Int32InputField : DialogInputField<int>
     {
-    }
-    
-    protected override void DrawFieldValue(Rect rect)
-    {
-        SmartValue = EditorGUI.IntField(rect, SmartValue);
-    }
-}
+        public Int32InputField(string label, string tooltip = null, int initialValue = default(int))
+            : base(label, tooltip, initialValue)
+        {
+        }
 
-public class BoolInputField : DialogInputField<bool>
-{
-    public BoolInputField(string label, string tooltip = null, bool initialValue = default(bool))
-        : base(label, tooltip, initialValue)
-    {
-    }
-    
-    protected override void DrawFieldValue(Rect rect)
-    {
-        SmartValue = EditorGUI.Toggle(rect, SmartValue);
-    }
-}
-
-public class FloatInputField : DialogInputField<float>
-{
-    public FloatInputField(string label, string tooltip = null, float initialValue = default(float))
-        : base(label, tooltip, initialValue)
-    {
+        protected override void DrawFieldValue(Rect rect)
+        {
+            SmartValue = EditorGUI.IntField(rect, SmartValue);
+        }
     }
 
-
-    protected override void DrawFieldValue(Rect rect)
+    public class BoolInputField : DialogInputField<bool>
     {
-        SmartValue = EditorGUI.FloatField(rect, SmartValue);
+        public BoolInputField(string label, string tooltip = null, bool initialValue = default(bool))
+            : base(label, tooltip, initialValue)
+        {
+        }
+
+        protected override void DrawFieldValue(Rect rect)
+        {
+            SmartValue = EditorGUI.Toggle(rect, SmartValue);
+        }
+    }
+
+    public class FloatInputField : DialogInputField<float>
+    {
+        public FloatInputField(string label, string tooltip = null, float initialValue = default(float))
+            : base(label, tooltip, initialValue)
+        {
+        }
+
+
+        protected override void DrawFieldValue(Rect rect)
+        {
+            SmartValue = EditorGUI.FloatField(rect, SmartValue);
+        }
     }
 }

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/AnimationCurveHeightAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/AnimationCurveHeightAttributeDrawer.cs
@@ -1,5 +1,5 @@
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector.Editor;
-using Sirenix.Utilities.Editor;
 using UnityEditor;
 using UnityEngine;
 

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/AnimationCurveHeightAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/AnimationCurveHeightAttributeDrawer.cs
@@ -3,7 +3,7 @@ using Sirenix.Utilities.Editor;
 using UnityEditor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     public class AnimationCurveHeightAttributeDrawer : OdinAttributeDrawer<AnimationCurveHeightAttribute, AnimationCurve>
     {

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/AssignableTypeFilterAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/AssignableTypeFilterAttributeDrawer.cs
@@ -11,7 +11,7 @@ using UnityEditor;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     [DrawerPriority(0.0, 0.0, 2002.0)]
     public sealed class AssignableTypeFilterAttributeDrawer : OdinAttributeDrawer<AssignableTypeFilterAttribute>

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/AssignableTypeFilterAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/AssignableTypeFilterAttributeDrawer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.OdinInspector.Editor.Drawers;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/Base/InlineIconAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/Base/InlineIconAttributeDrawer.cs
@@ -4,7 +4,7 @@ using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     public abstract class InlineIconAttributeDrawer<T, TValue> : OdinAttributeDrawer<T, TValue> where T : Attribute
     {

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/BoldLabelAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/BoldLabelAttributeDrawer.cs
@@ -3,7 +3,7 @@ using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities.Editor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     public class BoldLabelAttributeDrawer : OdinAttributeDrawer<BoldLabelAttribute>
     {

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/BoldLabelAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/BoldLabelAttributeDrawer.cs
@@ -1,3 +1,4 @@
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities.Editor;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/DrawAsObjectPickerAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/DrawAsObjectPickerAttributeDrawer.cs
@@ -1,3 +1,4 @@
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities.Editor;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/DrawAsObjectPickerAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/DrawAsObjectPickerAttributeDrawer.cs
@@ -3,7 +3,7 @@ using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities.Editor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     [DrawerPriority(0.0, 0.0, 3500.0)]
     public class DrawAsObjectPickerAttributeDrawer<T> : OdinAttributeDrawer<DrawAsUnityObjectAttribute, T> where T : Object

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/EditableLabelAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/EditableLabelAttributeDrawer.cs
@@ -1,4 +1,5 @@
 using System;
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/EditableLabelAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/EditableLabelAttributeDrawer.cs
@@ -6,7 +6,7 @@ using Sirenix.Utilities.Editor;
 using UnityEditor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     public class EditableLabelAttributeDrawer : OdinAttributeDrawer<EditableLabelAttribute>
     {

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/FittedLabelAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/FittedLabelAttributeDrawer.cs
@@ -1,7 +1,6 @@
-using Rhinox.GUIUtils.Odin.Editor;
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector;
 using Sirenix.OdinInspector.Editor;
-using Sirenix.Utilities;
 using Sirenix.Utilities.Editor;
 using UnityEngine;
 

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/FittedLabelAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/FittedLabelAttributeDrawer.cs
@@ -5,7 +5,7 @@ using Sirenix.Utilities;
 using Sirenix.Utilities.Editor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     [DrawerPriority(DrawerPriorityLevel.SuperPriority)]
     public class FittedLabelAttributeDrawer : OdinAttributeDrawer<FittedLabelAttribute>

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/FoldoutContainerAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/FoldoutContainerAttributeDrawer.cs
@@ -1,9 +1,8 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Rhinox.GUIUtils.Attributes;
 using Rhinox.GUIUtils.Editor;
-using Rhinox.GUIUtils.Odin.Editor;
-using Sirenix.OdinInspector;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities.Editor;
 using UnityEngine;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/FoldoutContainerAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/FoldoutContainerAttributeDrawer.cs
@@ -8,7 +8,7 @@ using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities.Editor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     public class FoldoutContainerAttributeDrawer : OdinGroupDrawer<FoldoutContainerAttribute>
     {

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/GenericValueAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/GenericValueAttributeDrawer.cs
@@ -1,5 +1,5 @@
 using System;
-using Rhinox.GUIUtils.Odin.Editor;
+using Rhinox.GUIUtils.Attributes;
 using Rhinox.Lightspeed.Reflection;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities.Editor;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/GenericValueAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/GenericValueAttributeDrawer.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 using Object = UnityEngine.Object;
 using SerializationUtility = Sirenix.Serialization.SerializationUtility;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     [DrawerPriority(0, 0, 2500)]
     public class GenericValueAttributeDrawer : OdinAttributeDrawer<GenericValueAttribute>

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/IconToggleAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/IconToggleAttributeDrawer.cs
@@ -6,7 +6,7 @@ using Sirenix.Utilities.Editor;
 using UnityEditor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     public class IconToggleAttributeDrawer : OdinAttributeDrawer<IconToggleAttribute, bool>
     {

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/IconToggleAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/IconToggleAttributeDrawer.cs
@@ -1,7 +1,6 @@
 ﻿using System.Reflection;
-using Sirenix.OdinInspector;
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector.Editor;
-using Sirenix.Utilities;
 using Sirenix.Utilities.Editor;
 using UnityEditor;
 using UnityEngine;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/InlineEditorIconAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/InlineEditorIconAttributeDrawer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Reflection;
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities;
 using Sirenix.Utilities.Editor;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/InlineEditorIconAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/InlineEditorIconAttributeDrawer.cs
@@ -6,7 +6,7 @@ using Sirenix.Utilities.Editor;
 using UnityEditor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     [DrawerPriority(DrawerPriorityLevel.WrapperPriority)]
     public class InlineEditorIconAttributeDrawer<T> : OdinAttributeDrawer<InlineEditorIconAttribute, T>

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/InlineErrorAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/InlineErrorAttributeDrawer.cs
@@ -1,11 +1,8 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using Sirenix.OdinInspector;
+﻿using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.OdinInspector.Editor.Drawers;
 using Sirenix.Utilities;
 using Sirenix.Utilities.Editor;
-using UnityEditor;
 using UnityEngine;
 
 namespace Rhinox.GUIUtils.Odin.Editor

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/InlineErrorAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/InlineErrorAttributeDrawer.cs
@@ -8,7 +8,7 @@ using Sirenix.Utilities.Editor;
 using UnityEditor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     [DrawerPriority(DrawerPriorityLevel.WrapperPriority)]
     public class InlineErrorAttributeDrawer<T> : InlineIconAttributeDrawer<InlineErrorAttribute, T>

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/InlineIconButtonAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/InlineIconButtonAttributeDrawer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities;
 using Sirenix.Utilities.Editor;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/InlineIconButtonAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/InlineIconButtonAttributeDrawer.cs
@@ -6,7 +6,7 @@ using Sirenix.Utilities.Editor;
 using UnityEditor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     [DrawerPriority(DrawerPriorityLevel.WrapperPriority)]
     public class InlineIconButtonAttributeDrawer<T> : OdinAttributeDrawer<InlineIconButtonAttribute, T>

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/InlinePropertyAltAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/InlinePropertyAltAttributeDrawer.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using Sirenix.OdinInspector;
+﻿using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities;
 using Sirenix.Utilities.Editor;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/InlinePropertyAltAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/InlinePropertyAltAttributeDrawer.cs
@@ -7,7 +7,7 @@ using Sirenix.Utilities.Editor;
 using UnityEditor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     [DrawerPriority(0.0, 0.0, 0.11)]
     public class InlinePropertyAltAttributeDrawer : OdinAttributeDrawer<InlinePropertyAltAttribute>

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/InlineWarningAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/InlineWarningAttributeDrawer.cs
@@ -6,7 +6,7 @@ using Sirenix.Utilities;
 using Sirenix.Utilities.Editor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     public class InlineWarningAttributeDrawer<T> : InlineIconAttributeDrawer<InlineWarningAttribute, T>
     {

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/InlineWarningAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/InlineWarningAttributeDrawer.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using Sirenix.OdinInspector;
+﻿using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector.Editor.Drawers;
 using Sirenix.Utilities;
 using Sirenix.Utilities.Editor;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/LayerAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/LayerAttributeDrawer.cs
@@ -3,7 +3,7 @@ using Sirenix.OdinInspector.Editor;
 using UnityEditor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     public class LayerAttributeDrawer : OdinAttributeDrawer<LayerAttribute, int>
     {

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/LayerAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/LayerAttributeDrawer.cs
@@ -1,4 +1,4 @@
-using Sirenix.OdinInspector;
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector.Editor;
 using UnityEditor;
 using UnityEngine;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ListItemSelectorAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ListItemSelectorAttributeDrawer.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using System;
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities.Editor;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ListItemSelectorAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ListItemSelectorAttributeDrawer.cs
@@ -6,7 +6,7 @@ using Sirenix.Utilities.Editor;
 using UnityEditor;
 using Sirenix.Utilities;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     [DrawerPriority(0.01, 0, 0)]
     public class ListItemSelectorAttributeDrawer : OdinAttributeDrawer<ListItemSelectorAttribute>

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/OptionalValueAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/OptionalValueAttributeDrawer.cs
@@ -6,7 +6,7 @@ using Sirenix.Utilities.Editor;
 using UnityEditor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     [DrawerPriority(DrawerPriorityLevel.WrapperPriority)]
     public class OptionalValueAttributeDrawer : OdinAttributeDrawer<OptionalValueAttribute>

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/OptionalValueAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/OptionalValueAttributeDrawer.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector.Editor;
 using Rhinox.Lightspeed;
 using Rhinox.Lightspeed.Reflection;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/OverrideGroupAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/OverrideGroupAttributeDrawer.cs
@@ -1,3 +1,4 @@
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/OverrideGroupAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/OverrideGroupAttributeDrawer.cs
@@ -4,7 +4,7 @@ using Sirenix.Utilities;
 using UnityEditor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     public class OverrideGroupAttributeDrawer : OdinGroupDrawer<OverrideGroupAttribute>
     {

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/PageSliderAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/PageSliderAttributeDrawer.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Linq;
-using Sirenix.OdinInspector;
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities;
 using Sirenix.Utilities.Editor;
-using UnityEditor;
 using UnityEngine;
 
 namespace Rhinox.GUIUtils.Odin

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/PropertiesGroupDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/PropertiesGroupDrawer.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Linq;
-using Sirenix.OdinInspector;
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector.Editor;
-using Sirenix.Utilities;
 using Sirenix.Utilities.Editor;
 using UnityEditor;
 using UnityEngine;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/PropertiesGroupDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/PropertiesGroupDrawer.cs
@@ -7,7 +7,7 @@ using Sirenix.Utilities.Editor;
 using UnityEditor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     public class PropertiesGroupDrawer : OdinGroupDrawer<PropertiesGroupAttribute>
     {

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/SearchPropertyAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/SearchPropertyAttributeDrawer.cs
@@ -7,7 +7,7 @@ using Sirenix.Utilities;
 using Sirenix.Utilities.Editor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     public class SearchPropertyAttributeDrawer : OdinAttributeDrawer<SearchPropertyAttribute, string>
     {

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/SearchPropertyAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/SearchPropertyAttributeDrawer.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ShaderParameterSelectorAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ShaderParameterSelectorAttributeDrawer.cs
@@ -11,7 +11,7 @@ using Sirenix.Utilities.Editor;
 using UnityEditor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     public class ShaderParameterSelectorAttributeDrawer : OdinAttributeDrawer<ShaderParameterSelectorAttribute, string>
     {

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ShaderParameterSelectorAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ShaderParameterSelectorAttributeDrawer.cs
@@ -1,10 +1,6 @@
-using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using Rhinox.GUIUtils.Odin.Editor;
-using Sirenix.OdinInspector;
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities;
 using Sirenix.Utilities.Editor;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/TagSelectorAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/TagSelectorAttributeDrawer.cs
@@ -1,7 +1,5 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using Sirenix.OdinInspector;
+﻿using System.Linq;
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities.Editor;
 using Rhinox.Lightspeed;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/TagSelectorAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/TagSelectorAttributeDrawer.cs
@@ -7,7 +7,7 @@ using Sirenix.Utilities.Editor;
 using Rhinox.Lightspeed;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     public class TagSelectorAttributeDrawer : OdinAttributeDrawer<TagSelectorAttribute, string>
     {

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ToggleButtonAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ToggleButtonAttributeDrawer.cs
@@ -7,7 +7,7 @@ using Sirenix.Utilities.Editor;
 using UnityEditor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     public class ToggleButtonAttributeDrawer : OdinAttributeDrawer<ToggleButtonAttribute, bool>
     {

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ToggleButtonAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ToggleButtonAttributeDrawer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ToggleButtonGroupDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ToggleButtonGroupDrawer.cs
@@ -3,7 +3,7 @@ using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities.Editor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     public class ToggleButtonGroupDrawer : OdinGroupDrawer<ToggleButtonAttribute>
     {

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ToggleButtonGroupDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ToggleButtonGroupDrawer.cs
@@ -1,4 +1,5 @@
 using System;
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities.Editor;
 using UnityEngine;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ToggleButtonOppositeAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ToggleButtonOppositeAttributeDrawer.cs
@@ -6,7 +6,7 @@ using Sirenix.Utilities.Editor;
 using UnityEditor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     public class ToggleButtonOppositeAttributeDrawer : OdinAttributeDrawer<ToggleButtonOppositeAttribute, bool>
     {

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ToggleButtonOppositeAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ToggleButtonOppositeAttributeDrawer.cs
@@ -1,5 +1,4 @@
-using Rhinox.GUIUtils.Odin.Editor;
-using Sirenix.OdinInspector;
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities;
 using Sirenix.Utilities.Editor;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ToggledByAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ToggledByAttributeDrawer.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using Rhinox.GUIUtils.Odin.Editor;
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities;
 using Sirenix.Utilities.Editor;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ToggledByAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ToggledByAttributeDrawer.cs
@@ -10,7 +10,7 @@ using Sirenix.Utilities.Editor;
 using UnityEditor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     [DrawerPriority(DrawerPriorityLevel.SuperPriority)]
     public class ToggledByAttributeDrawer : OdinAttributeDrawer<ToggledByAttribute>

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/UnfoldListAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/UnfoldListAttributeDrawer.cs
@@ -7,7 +7,7 @@ using Sirenix.Utilities;
 using Sirenix.Utilities.Editor;
 using UnityEngine;
 
-namespace Rhinox.GUIUtils.Odin
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     [DrawerPriority(0, 1000, 0)]
     public class UnfoldListAttributeDrawer : OdinAttributeDrawer<UnfoldListAttribute>

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/UnfoldListAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/UnfoldListAttributeDrawer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Reflection;
 using Rhinox.GUIUtils;
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities;
 using Sirenix.Utilities.Editor;

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Values/ExtendedSerializableTypeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Values/ExtendedSerializableTypeDrawer.cs
@@ -1,14 +1,12 @@
 ﻿#if ODIN_INSPECTOR
 using System.Linq;
-using Rhinox.GUIUtils.Odin;
 using Sirenix.OdinInspector.Editor;
 
-namespace Rhinox.Lightspeed.Editor
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     [DrawerPriority(0, 0, 2004)]
     public class ExtendedSerializableTypeDrawer : SerializableTypeDrawer
     {
-
         protected override void Initialize()
         {
             base.Initialize();

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Values/ExtendedSerializableTypeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Values/ExtendedSerializableTypeDrawer.cs
@@ -1,5 +1,7 @@
 ﻿#if ODIN_INSPECTOR
 using System.Linq;
+using Rhinox.GUIUtils.Attributes;
+using Rhinox.Lightspeed.Editor;
 using Sirenix.OdinInspector.Editor;
 
 namespace Rhinox.GUIUtils.Odin.Editor

--- a/Assets/GUIUtils/Odin/Editor/Processors/InheritClassAttributeAttributesAttributeProcessor.cs
+++ b/Assets/GUIUtils/Odin/Editor/Processors/InheritClassAttributeAttributesAttributeProcessor.cs
@@ -4,42 +4,45 @@ using System.Reflection;
 using Sirenix.OdinInspector;
 using Sirenix.OdinInspector.Editor;
 
-[ResolverPriority(-100000.0)]
-public class InheritClassAttributeAttributesAttributeProcessor : OdinAttributeProcessor
+namespace Rhinox.GUIUtils.Odin.Editor
 {
-    public override bool CanProcessSelfAttributes(InspectorProperty property)
+    [ResolverPriority(-100000.0)]
+    public class InheritClassAttributeAttributesAttributeProcessor : OdinAttributeProcessor
     {
-        if (!base.CanProcessSelfAttributes(property))
-            return false;
-        
+        public override bool CanProcessSelfAttributes(InspectorProperty property)
+        {
+            if (!base.CanProcessSelfAttributes(property))
+                return false;
+
 #if ODIN_INSPECTOR_3
         if (property.IsTreeRoot)
             return true;
 #endif
-        return property.Parent == null;
-    }
+            return property.Parent == null;
+        }
 
-    public override void ProcessSelfAttributes(InspectorProperty property, List<Attribute> attributes)
-    {
-        base.ProcessSelfAttributes(property, attributes);
-        
-        for (int index = attributes.Count - 1; index >= 0; --index)
+        public override void ProcessSelfAttributes(InspectorProperty property, List<Attribute> attributes)
         {
-            Type type = attributes[index].GetType();
-            if (type.IsDefined(typeof (IncludeMyAttributesAttribute), false))
-            {
-                foreach (object customAttribute in type.GetCustomAttributes(false))
-                {
-                    if (customAttribute is AttributeUsageAttribute)
-                        continue;
-                    
-                    if (customAttribute is IncludeMyAttributesAttribute)
-                        continue;
-                    
-                    attributes.Add(customAttribute as Attribute);
-                }
+            base.ProcessSelfAttributes(property, attributes);
 
-                attributes.RemoveAt(index);
+            for (int index = attributes.Count - 1; index >= 0; --index)
+            {
+                Type type = attributes[index].GetType();
+                if (type.IsDefined(typeof(IncludeMyAttributesAttribute), false))
+                {
+                    foreach (object customAttribute in type.GetCustomAttributes(false))
+                    {
+                        if (customAttribute is AttributeUsageAttribute)
+                            continue;
+
+                        if (customAttribute is IncludeMyAttributesAttribute)
+                            continue;
+
+                        attributes.Add(customAttribute as Attribute);
+                    }
+
+                    attributes.RemoveAt(index);
+                }
             }
         }
     }

--- a/Assets/GUIUtils/Odin/Editor/Processors/OrderRelativeToAttributePropertyProcessor.cs
+++ b/Assets/GUIUtils/Odin/Editor/Processors/OrderRelativeToAttributePropertyProcessor.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-using Rhinox.GUIUtils.Odin;
+using Rhinox.GUIUtils.Attributes;
 using Sirenix.OdinInspector;
 using Sirenix.OdinInspector.Editor;
 using UnityEngine;

--- a/Assets/GUIUtils/Odin/Editor/Utils/OdinContextProvider.cs
+++ b/Assets/GUIUtils/Odin/Editor/Utils/OdinContextProvider.cs
@@ -1,24 +1,28 @@
 ﻿using Sirenix.OdinInspector.Editor;
 using Sirenix.Serialization;
 
-public class OdinContextProvider
+namespace Rhinox.GUIUtils.Odin.Editor
 {
-    protected LocalPersistentContext<T> GetPersistentValue<T>(string key, T defaultValue = default(T))
+    public class OdinContextProvider
     {
-        GlobalPersistentContext<T> context;
-        if (PersistentContext.Get(TwoWaySerializationBinder.Default.BindToName(GetType()), key, out context))
-            context.Value = defaultValue;
-        return LocalPersistentContext<T>.Create(context);
+        protected LocalPersistentContext<T> GetPersistentValue<T>(string key, T defaultValue = default(T))
+        {
+            GlobalPersistentContext<T> context;
+            if (PersistentContext.Get(TwoWaySerializationBinder.Default.BindToName(GetType()), key, out context))
+                context.Value = defaultValue;
+            return LocalPersistentContext<T>.Create(context);
+        }
     }
-}
 
-public static class OdinPersistentContextHelper
-{
-    public static LocalPersistentContext<T> GetPersistentValue<T>(this OdinEditor editor, string key, T defaultValue = default(T))
+    public static class OdinPersistentContextHelper
     {
-        GlobalPersistentContext<T> context;
-        if (PersistentContext.Get(TwoWaySerializationBinder.Default.BindToName(editor.GetType()), key, out context))
-            context.Value = defaultValue;
-        return LocalPersistentContext<T>.Create(context);
+        public static LocalPersistentContext<T> GetPersistentValue<T>(this OdinEditor editor, string key,
+            T defaultValue = default(T))
+        {
+            GlobalPersistentContext<T> context;
+            if (PersistentContext.Get(TwoWaySerializationBinder.Default.BindToName(editor.GetType()), key, out context))
+                context.Value = defaultValue;
+            return LocalPersistentContext<T>.Create(context);
+        }
     }
 }

--- a/Assets/GUIUtils/package.json
+++ b/Assets/GUIUtils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.rhinox.open.guiutils",
   "displayName": "GUIUtils - Editor Graphical UI Extensions",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "unity": "2019.3",
   "description": "GUI Utils for Unity projects, mostly Editor extensions. (Optional Odin extensions)",
   "keywords": [

--- a/Assets/Tests/Editor/InputDialogTester.cs
+++ b/Assets/Tests/Editor/InputDialogTester.cs
@@ -1,10 +1,12 @@
-﻿using UnityEditor;
+﻿using Rhinox.GUIUtils.Editor;
+using UnityEditor;
 using UnityEngine;
 
 namespace Tests
 {
     public static class InputDialogTester
     {
+#if UNITY_EDITOR
         [MenuItem("Rhinox/GUIUtils/Test Dialog")]
         public static void TryDialog()
         {
@@ -27,6 +29,7 @@ namespace Tests
                     Debug.Log(textureValue.Value);
                 })
                 .Show();
-        }        
+        }
+#endif
     }
 }

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -584,7 +584,7 @@ PlayerSettings:
   webGLThreadsSupport: 0
   webGLWasmStreaming: 0
   scriptingDefineSymbols:
-    1: 
+    1: ODIN_INSPECTOR
   platformArchitecture: {}
   scriptingBackend: {}
   il2cppCompilerConfiguration: {}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -584,7 +584,7 @@ PlayerSettings:
   webGLThreadsSupport: 0
   webGLWasmStreaming: 0
   scriptingDefineSymbols:
-    1: ODIN_INSPECTOR
+    1: 
   platformArchitecture: {}
   scriptingBackend: {}
   il2cppCompilerConfiguration: {}


### PR DESCRIPTION
### Changes
- Changed namespace of all attributes in com.rhinox.open.guiutils.attributes to Rhinox.GUIUtils.Attributes
- Changed namespaces of some drawers to Rhinox.GUIUtils.Odin.Editor since they were in the editor assembly 
- Added namespace Rhinox.GUIUtils.Editor to EditorInputDialog and related classes