### PR TITLE
Hotfix/v2.0.0

### DIFF
--- a/Assets/GUIUtils/Editor/GUI/Data/List/BetterReorderableList.cs
+++ b/Assets/GUIUtils/Editor/GUI/Data/List/BetterReorderableList.cs
@@ -101,13 +101,13 @@ namespace Rhinox.GUIUtils.Editor
             if (elementList != null)
             {
                 this.m_ListType = elementList.GetType();
-                this.m_ElementType = this.m_ListType.GetElementType();
+                this.m_ElementType = this.m_ListType.GetCollectionElementType();
             }
             else
             {
                 System.Reflection.FieldInfo fi = elements.FindFieldInfo();
                 this.m_ListType = fi.FieldType;
-                this.m_ElementType = GetItemType(this.m_ListType);
+                this.m_ElementType = this.m_ListType.GetCollectionElementType();
             }
             
             this.m_Draggable = draggable;
@@ -121,12 +121,6 @@ namespace Rhinox.GUIUtils.Editor
             if (this.m_Elements == null || this.m_Elements.isArray)
                 return;
             Debug.LogError((object) "Input elements should be an Array SerializedProperty");
-        }
-        
-        // TODO safe option?
-        static Type GetItemType(Type collectionType)
-        {
-            return collectionType.GetMethod("get_Item").ReturnType;
         }
 
         public SerializedProperty serializedProperty
@@ -761,7 +755,7 @@ namespace Rhinox.GUIUtils.Editor
                 }
                 else
                 {
-                    System.Type elementType = list.list.GetType().GetElementType();
+                    System.Type elementType = list.list.GetType().GetCollectionElementType();
                     if (elementType == typeof(string))
                         list.index = list.list.Add((object) "");
                     else if (elementType != null && elementType.GetConstructor(System.Type.EmptyTypes) == null)

--- a/Assets/GUIUtils/Editor/GUI/Data/List/BetterReorderableList.cs
+++ b/Assets/GUIUtils/Editor/GUI/Data/List/BetterReorderableList.cs
@@ -105,9 +105,7 @@ namespace Rhinox.GUIUtils.Editor
             }
             else
             {
-                System.Type parentType = elements.serializedObject.targetObject.GetType();
-                System.Reflection.FieldInfo fi = parentType.GetField(elements.propertyPath);
-
+                System.Reflection.FieldInfo fi = elements.FindFieldInfo();
                 this.m_ListType = fi.FieldType;
                 this.m_ElementType = GetItemType(this.m_ListType);
             }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
@@ -197,7 +197,7 @@ namespace Rhinox.GUIUtils.Editor
                 composite.AddRange(subdrawables);
                 resultingMember = composite;
             }
-            catch (Exception e)
+            catch (Exception /*e*/)
             {
                 resultingMember = null;
             }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
@@ -70,9 +70,12 @@ namespace Rhinox.GUIUtils.Editor
             if (property == null)
                 return null;
             
-            var visibleFields = property.EnumerateEditorVisibleFields();
             object instanceVal = property.GetValue();
             
+            if (type == typeof(GameObject))
+                return new List<IOrderedDrawable>() {new DrawableUnityObject(instanceVal)};
+            
+            var visibleFields = property.EnumerateEditorVisibleFields();
             return DrawableMembersFor(instanceVal, type, visibleFields, depth);
         }
 
@@ -125,14 +128,19 @@ namespace Rhinox.GUIUtils.Editor
 
         private static List<IOrderedDrawable> CreateDrawableMembersFor(SerializedObject obj, Type type, int depth)
         {
-            var visibleFields = obj.EnumerateEditorVisibleFields();
             object instanceVal = obj.targetObject;
             
+            if (type == typeof(GameObject))
+                return new List<IOrderedDrawable>() {new DrawableUnityObject(instanceVal)};
+            
+            var visibleFields = obj.EnumerateEditorVisibleFields();
             return DrawableMembersFor(instanceVal, type, visibleFields, depth);
         }
 
         public static List<IOrderedDrawable> CreateDrawableMembersFor(object instance, Type t)
         {
+            if (t == typeof(GameObject))
+                return new List<IOrderedDrawable>() {new DrawableUnityObject(instance)};
             return CreateDrawableMembersFor(instance, t, 0);
         }
 

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
@@ -67,6 +67,9 @@ namespace Rhinox.GUIUtils.Editor
 
         private static List<IOrderedDrawable> CreateDrawableMembersFor(SerializedProperty property, Type type, int depth)
         {
+            if (property == null)
+                return null;
+            
             var visibleFields = property.EnumerateEditorVisibleFields();
             object instanceVal = property.GetValue();
             

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawableGroupingHelper.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawableGroupingHelper.cs
@@ -10,11 +10,14 @@ namespace Rhinox.GUIUtils.Editor
     {
         private const string GroupingString = "/";
         
-        public static void Process(ref List<IOrderedDrawable> drawables)
+        public static bool Process(ref List<IOrderedDrawable> drawables)
         {
+            if (drawables == null)
+                return false;
+
             var drawablesByGroup = CreateLookupByGroupAttribute(drawables);
             if (drawablesByGroup.IsNullOrEmpty())
-                return;
+                return false;
 
             var remainingGroupings = drawablesByGroup.Keys.ToList();
             remainingGroupings.SortByDescending(x => x.GroupID.Length);
@@ -119,6 +122,7 @@ namespace Rhinox.GUIUtils.Editor
 
             // Return list
             drawables = finalList;
+            return true;
         }
 
         private static bool IsParentOf(PropertyGroupAttribute entry, PropertyGroupAttribute potentialParent)

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
@@ -141,7 +141,7 @@ namespace Rhinox.GUIUtils.Editor
                     continue;
                 rect.height = drawable.ElementHeight;
                 drawable.Draw(rect);
-                rect.y += rect.height;
+                rect.y += rect.height + 2.0f;
             }
         }
     }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
@@ -20,7 +20,7 @@ namespace Rhinox.GUIUtils.Editor
                 float height = 0.0f;
                 foreach (var drawable in _drawables)
                     height += drawable.ElementHeight;
-                return height;
+                return height + (Math.Max(0, _drawables.Count - 1) * 2.0f);
             }
         }
 

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
@@ -66,9 +66,13 @@ namespace Rhinox.GUIUtils.Editor
             if (drawables.Count == 0 && obj is UnityEngine.Object unityObj)
                 drawables.Add(new DrawableUnityObject(unityObj));
 
-            DrawableGroupingHelper.Process(ref drawables);
+            if (!drawables.IsNullOrEmpty())
+            {
+                DrawableGroupingHelper.Process(ref drawables);
 
-            drawables.SortDrawables();
+                drawables.SortDrawables();
+            }
+
             return drawables;
         }
 
@@ -85,9 +89,12 @@ namespace Rhinox.GUIUtils.Editor
 
             var drawables = DrawableFactory.CreateDrawableMembersFor(property, type);
 
-            DrawableGroupingHelper.Process(ref drawables);
+            if (!drawables.IsNullOrEmpty())
+            {
+                DrawableGroupingHelper.Process(ref drawables);
 
-            drawables.SortDrawables();
+                drawables.SortDrawables();
+            }
 
             return drawables;
         }
@@ -101,14 +108,20 @@ namespace Rhinox.GUIUtils.Editor
 
             var drawables = DrawableFactory.CreateDrawableMembersFor(obj, type);
 
-            DrawableGroupingHelper.Process(ref drawables);
+            if (!drawables.IsNullOrEmpty())
+            {
+                DrawableGroupingHelper.Process(ref drawables);
 
-            drawables.SortDrawables();
+                drawables.SortDrawables();
+            }
             return drawables;
         }
         
         public void DrawLayout()
         {
+            if (_drawables == null)
+                return;
+            
             foreach (var drawable in _drawables)
             {
                 if (drawable == null)
@@ -119,6 +132,9 @@ namespace Rhinox.GUIUtils.Editor
         
         public void Draw(Rect rect)
         {
+            if (_drawables == null)
+                return;
+            
             foreach (var drawable in _drawables)
             {
                 if (drawable == null)

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableList.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableList.cs
@@ -18,7 +18,9 @@ namespace Rhinox.GUIUtils.Editor
         {
             get
             {
-                if (_property != null)
+                if (_propertyView != null)
+                    return _propertyView.Height;
+                else if (_property != null)
                 {
                     if (_property.isExpanded)
                     {
@@ -26,9 +28,6 @@ namespace Rhinox.GUIUtils.Editor
                         return height;
                     }
                 }
-                else if (_propertyView != null)
-                    return _propertyView.Height;
-
                 return _defaultElementHeight;
             }
         }
@@ -115,7 +114,7 @@ namespace Rhinox.GUIUtils.Editor
             get
             {
                 if (_listRO != null)
-                    return _listRO.GetHeight();
+                    return IsReadOnly ? _listRO.GetHeight() : _listRO.GetHeight() + 24.0f; // (+) icon include
                 return base.ElementHeight;
             }
         }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableList.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableList.cs
@@ -20,21 +20,11 @@ namespace Rhinox.GUIUtils.Editor
             {
                 if (_propertyView != null)
                     return _propertyView.Height;
-                else if (_property != null)
-                {
-                    if (_property.isExpanded)
-                    {
-                        float height = EditorGUI.GetPropertyHeight(_property, true);
-                        return height;
-                    }
-                }
                 return _defaultElementHeight;
             }
         }
 
-        //private readonly ICollection<IOrderedDrawable> _drawables;
         private readonly float _defaultElementHeight;
-        private readonly HostInfo _hostInfo;
         private readonly SerializedProperty _property;
         private readonly DrawablePropertyView _propertyView;
 
@@ -43,58 +33,22 @@ namespace Rhinox.GUIUtils.Editor
             if (property == null) throw new ArgumentNullException(nameof(property));
             _defaultElementHeight = defaultElementHeight;
             _property = property;
-            _hostInfo = property.GetHostInfo();
-            
             _propertyView = new DrawablePropertyView(property, drawElementsAsUnity);
-            //if (drawElementsAsUnity)
-            //    _drawables = new[] {new UnityDrawableProperty(property)};
-            //else
-            //{
-                //_propertyView = new DrawablePropertyView(property);
-                
-                // if (property.exposedReferenceValue != null)
-                // {
-                //     _drawables = DrawableFactory.ParseSerializedObject(new SerializedObject(property.exposedReferenceValue));
-                // }
-                // else
-                // {
-                //     var reflectedValue = _hostInfo.GetValue();
-                //     if (reflectedValue is UnityEngine.Object unityReflectedVal)
-                //         _drawables = DrawableFactory.ParseSerializedObject(new SerializedObject(unityReflectedVal));
-                //     else if (reflectedValue != null)
-                //         _drawables = DrawableFactory.ParseNonUnityObject(reflectedValue);
-                // }
-            //}
-            
         }
 
         public ListElementDrawable(object element, float defaultElementHeight = 18.0f, bool drawElementsAsUnity = false)
         {
             if (element == null) throw new ArgumentNullException(nameof(element));
             _defaultElementHeight = defaultElementHeight;
+            _property = null;
             _propertyView = new DrawablePropertyView(element, drawElementsAsUnity);
-            // _drawables = drawElementsAsUnity && element is UnityEngine.Object ?
-            //     new [] { new DrawableUnityObject((UnityEngine.Object)element) } :
-            //     DrawableFactory.ParseNonUnityObject(element);
         }
 
         public void Draw(Rect r)
         {
-            if (_propertyView == null && _hostInfo != null && _property != null)
-            {
-                var label = GUIContentHelper.TempContent(_hostInfo.GetReturnType().Name);
-                EditorGUI.BeginProperty(r, label, _property);
-                {
-                    EditorGUI.PropertyField(r, _property, label, true);
-                }
-                EditorGUI.EndProperty();
-                return;
-            }
-
-            //GUILayout.BeginArea(r);
+            r.y += 2.0f;
             if (_propertyView != null)
                 _propertyView.Draw(r);
-            // GUILayout.EndArea();
         }
     }
 
@@ -114,7 +68,7 @@ namespace Rhinox.GUIUtils.Editor
             get
             {
                 if (_listRO != null)
-                    return IsReadOnly ? _listRO.GetHeight() : _listRO.GetHeight() + 24.0f; // (+) icon include
+                    return _listRO.GetHeight();
                 return base.ElementHeight;
             }
         }

--- a/Assets/GUIUtils/Editor/GUI/GenericSmartObjectEditor.cs
+++ b/Assets/GUIUtils/Editor/GUI/GenericSmartObjectEditor.cs
@@ -2,13 +2,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Rhinox.GUIUtils.Attributes;
 using Rhinox.Lightspeed.Reflection;
 using Sirenix.OdinInspector;
 using UnityEngine;
 
 namespace Rhinox.GUIUtils.Editor
 {
-    [Serializable]
+    [Serializable, IgnoreInScriptableObjectCreator]
     public class SmartInternalObject : ScriptableObject
     {
         [SerializeField]

--- a/Assets/GUIUtils/Editor/GUI/GenericSmartObjectEditor.cs
+++ b/Assets/GUIUtils/Editor/GUI/GenericSmartObjectEditor.cs
@@ -36,7 +36,8 @@ namespace Rhinox.GUIUtils.Editor
 
         public override void OnInspectorGUI()
         {
-            _propertyView.DrawLayout();
+            if (_propertyView != null)
+                _propertyView.DrawLayout();
             if (_drawerMethod != null)
                 _drawerMethod.Invoke(_target, null);
         }

--- a/Assets/GUIUtils/Editor/Helpers/CustomMenuTree.cs
+++ b/Assets/GUIUtils/Editor/Helpers/CustomMenuTree.cs
@@ -143,12 +143,12 @@ namespace Rhinox.GUIUtils.Editor
             {
                 foreach (var subGroup in item.SubGroups)
                 {
-                    DrawGroupHeader(subGroup, evt, ++indent);
+                    DrawGroupHeader(subGroup, evt, indent + 1);
                 }
                 
                 foreach (var child in item.Children)
                 {
-                    child.DrawMenuItem(evt, indent+1, (x) => x.Substring(x.LastIndexOf(GroupingString) + GroupingString.Length));
+                    child.DrawMenuItem(evt, indent + 1, (x) => x.Substring(x.LastIndexOf(GroupingString) + GroupingString.Length));
                 }
             }
         }
@@ -186,7 +186,8 @@ namespace Rhinox.GUIUtils.Editor
                         hierarchy?.SubGroups.Add(next);
                         hierarchy = next;
                         dict[full] = next;
-                        _groupingItems.Add(next);
+                        if (i == 0)
+                            _groupingItems.Add(next);
                     }
                 }
 

--- a/Assets/GUIUtils/Editor/Helpers/CustomMenuTree.cs
+++ b/Assets/GUIUtils/Editor/Helpers/CustomMenuTree.cs
@@ -77,13 +77,11 @@ namespace Rhinox.GUIUtils.Editor
         // Constructor
         
         public CustomMenuTree()
+#if ODIN_INSPECTOR
+            : this(new OdinMenuTree())
+#endif
         {
             Selection = new List<IMenuItem>();
-#if ODIN_INSPECTOR
-            _menuTree = new OdinMenuTree();
-            _menuTree.Selection.SelectionChanged += OnOdinSelectionChanged;
-            _menuTree.Selection.SelectionConfirmed += OnOdinSelectionConfirmed;
-#endif
         }
 
 #if ODIN_INSPECTOR
@@ -91,6 +89,9 @@ namespace Rhinox.GUIUtils.Editor
         {
             _menuTree = tree;
             Selection = new List<IMenuItem>();
+            
+            _menuTree.Selection.SelectionChanged += OnOdinSelectionChanged;
+            _menuTree.Selection.SelectionConfirmed += OnOdinSelectionConfirmed;
         }
 #endif
 

--- a/Assets/GUIUtils/Editor/Helpers/HierarchyMenuItem.cs
+++ b/Assets/GUIUtils/Editor/Helpers/HierarchyMenuItem.cs
@@ -53,5 +53,21 @@ namespace Rhinox.GUIUtils.Editor
 
             return false;
         }
+
+        public override void Update()
+        {
+            base.Update();
+            if (SubGroups != null)
+            {
+                foreach (var group in SubGroups)
+                    group.Update();
+            }
+
+            if (Children != null)
+            {
+                foreach (var entry in Children)
+                    entry.Update();
+            }
+        }
     }
 }

--- a/Assets/GUIUtils/Editor/Helpers/PersistentValue.cs
+++ b/Assets/GUIUtils/Editor/Helpers/PersistentValue.cs
@@ -121,7 +121,7 @@ namespace Rhinox.GUIUtils.Editor
             }
         }
 
-        public static SimplePersistentContext<T> Create<TKey1, TKey2, T>(TKey1 key1, TKey2 key2,
+        public static SimplePersistentContext<T> Create<TKey1, TKey2>(TKey1 key1, TKey2 key2,
             T defaultVal = default(T))
         {
             string path = $"{SmartToString(key1)}//{SmartToString(key2)}";
@@ -129,7 +129,7 @@ namespace Rhinox.GUIUtils.Editor
             return context;
         }
         
-        public static SimplePersistentContext<T> Create<TKey1, TKey2, TKey3, T>(TKey1 key1, TKey2 key2, TKey3 key3,
+        public static SimplePersistentContext<T> Create<TKey1, TKey2, TKey3>(TKey1 key1, TKey2 key2, TKey3 key3,
             T defaultVal = default(T))
         {
             string path = $"{SmartToString(key1)}//{SmartToString(key2)}";

--- a/Assets/GUIUtils/Editor/Helpers/UIMenuItem.cs
+++ b/Assets/GUIUtils/Editor/Helpers/UIMenuItem.cs
@@ -100,6 +100,10 @@ namespace Rhinox.GUIUtils.Editor
             {
                 EditorGUI.DrawRect(Rect, new Color(0.243f, 0.372f, 0.588f, 1f));
             }
+            else if (IsHoveringItem)
+            {
+                EditorGUI.DrawRect(Rect, new Color(0.838f, 0.838f, 0.838f, 0.034f));
+            }
 
             if (_icon != null)
             {
@@ -157,7 +161,7 @@ namespace Rhinox.GUIUtils.Editor
             _icon = icon;
         }
 
-        public void Update()
+        public virtual void Update()
         {
             EventType type = Event.current.type;
 

--- a/Assets/GUIUtils/Editor/Windows/CustomMenuEditorWindow.cs
+++ b/Assets/GUIUtils/Editor/Windows/CustomMenuEditorWindow.cs
@@ -15,7 +15,6 @@ namespace Rhinox.GUIUtils.Editor
         [NonSerialized] private CustomMenuTree menuTree;
         [NonSerialized] private object trySelectObject;
         [SerializeField] [HideInInspector] private List<string> selectedItems = new List<string>();
-        [SerializeField] [HideInInspector] private bool resizableMenuWidth = true;
         [HideInInspector] private Vector2 _menuScrollPosition;
 
         private void ProjectWindowChanged() => isDirty = true;

--- a/Assets/GUIUtils/package.json
+++ b/Assets/GUIUtils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.rhinox.open.guiutils",
   "displayName": "GUIUtils - Editor Graphical UI Extensions",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "unity": "2019.4",
   "description": "GUI Utils for Unity projects, mostly Editor extensions. (Optional Odin extensions)",
   "keywords": [

--- a/Assets/GUIUtils/package.json
+++ b/Assets/GUIUtils/package.json
@@ -10,7 +10,7 @@
   ],
   "category": "Unity",
   "dependencies": {
-    "com.rhinox.open.lightspeed": "1.3.0"
+    "com.rhinox.open.lightspeed": "1.3.1"
   },
   "repository": {
     "type": "git",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -10,7 +10,7 @@
     }
   ],
   "dependencies": {
-    "com.rhinox.open.lightspeed": "1.3.0",
+    "com.rhinox.open.lightspeed": "1.3.1",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.ide.rider": "1.2.1",
     "com.unity.ide.visualstudio": "2.0.11",


### PR DESCRIPTION
### Added 
- SerializedObjectExtensions.FindFieldInfo: find Field Info even if a SerializeProperty points to an entry in a collection

### Fixes
- SerializedProperty.GetValue is now properly handled for Generic property types
- SerializedProperty.SetValue improved stability when pointing to collection entries
- BetterReorderableList now uses GetCollectionElementType extension from Lightspeed which is more stable than the local utility method
- DrawableFactory now handles GameObject instance types in CreateDrawableMembersFor
- Compiler warnings mostly removed
- DrawablePropertyView.Height was being calculated wrong
- DrawablePropertyView now has better null checks
- DrawableList clean up of code, better margin
- GenericSmartObjectEditor now stills draws property layout even if OnInspectorGUI method (Attribute) is used
- CustomMenuTree: grouping and drawing fixes