### PR TITLE
Ftr/additional fixes v2

### DIFF
--- a/Assets/GUIUtils/Attributes/SmartFallbackDrawnAttribute.cs
+++ b/Assets/GUIUtils/Attributes/SmartFallbackDrawnAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Rhinox.GUIUtils.Attributes
+{
+    public class SmartFallbackDrawnAttribute : Attribute
+    {
+        public bool AllowUnityIfAble { get; }
+        
+        public SmartFallbackDrawnAttribute(bool allowUnityIfAble = true)
+        {
+            AllowUnityIfAble = allowUnityIfAble;
+        }
+    }
+}

--- a/Assets/GUIUtils/Attributes/SmartFallbackDrawnAttribute.cs.meta
+++ b/Assets/GUIUtils/Attributes/SmartFallbackDrawnAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b2c717d9f4c04adfa75fbdfa76842722
+timeCreated: 1678380121

--- a/Assets/GUIUtils/Editor/Drawers.meta
+++ b/Assets/GUIUtils/Editor/Drawers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 074e56fc08ade774599a8a56c22f3e49
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/GUIUtils/Editor/Drawers/SceneReferenceDrawer.cs
+++ b/Assets/GUIUtils/Editor/Drawers/SceneReferenceDrawer.cs
@@ -1,0 +1,185 @@
+using System;
+using Rhinox.Lightspeed;
+using UnityEditor;
+using UnityEngine;
+
+namespace Rhinox.GUIUtils.Editor
+{
+    [CustomPropertyDrawer(typeof(SceneReferenceData), true)]
+    public class SceneReferenceDrawer : PropertyDrawer
+    {
+        private static readonly GUIStyle boxStyle = EditorStyles.helpBox;
+        private static readonly RectOffset boxPadding = boxStyle.padding;
+
+        private const float PAD_SIZE = 2f;
+        private const float FOOTER_HEIGHT = 10f;
+
+        private static readonly float lineHeight = EditorGUIUtility.singleLineHeight;
+        private static readonly float paddedLine = lineHeight + PAD_SIZE;
+        
+        //protected override void DrawPropertyLayout(GUIContent label)
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUILayout.BeginVertical(boxStyle);
+            using (new eUtility.IndentedLayout())
+            {
+                GUILayout.BeginHorizontal();
+
+                if (label != null)
+                    EditorGUILayout.PrefixLabel(label);
+
+                // Draw scene selector
+                SceneReferenceData smartValue = property.GetValue() as SceneReferenceData;
+                var asset = smartValue.SceneAsset;
+
+                var newAsset = EditorGUILayout.ObjectField(asset, typeof(SceneAsset), false);
+
+                if (newAsset != asset)
+                {
+                    if (newAsset != null)
+                    {
+                        // Call Constructor taking a SceneAsset
+                        smartValue = Activator.CreateInstance(fieldInfo.FieldType, new[] {newAsset}) as SceneReferenceData;
+                        property.SetValue(smartValue);
+                        property.serializedObject.ApplyModifiedProperties();
+                        asset = newAsset;
+                    }
+                    else
+                        smartValue.ScenePath = null;
+                }
+
+                // End of scene selector
+                GUILayout.EndHorizontal();
+
+                // Draw scene info
+                GUILayout.BeginHorizontal();
+
+                // Draw the Build Settings Info of the selected Scene
+                var buildScene = BuildUtils.GetBuildScene(asset);
+
+                if (!buildScene.assetGUID.Empty())
+                    DrawSceneInfoGUI(buildScene);
+
+                GUILayout.EndHorizontal();
+
+            }
+            EditorGUILayout.EndVertical();
+        }
+
+        private void DrawSceneInfoGUI(BuildUtils.BuildScene buildScene)
+        {
+            var readOnly = BuildUtils.IsReadOnly();
+            var readOnlyWarning =
+                readOnly ? "\n\nWARNING: Build Settings is not checked out and so cannot be modified." : "";
+
+            // Label Prefix
+            var iconContent = new GUIContent();
+            var labelContent = new GUIContent();
+
+            // Missing from build scenes
+            if (buildScene.buildIndex == -1)
+            {
+                iconContent = EditorGUIUtility.IconContent("d_winbtn_mac_close");
+                labelContent.text = "NOT In Build";
+                labelContent.tooltip = "This scene is NOT in build settings.\nIt will be NOT included in builds.";
+            }
+            // In build scenes and enabled
+            else if (buildScene.scene.enabled)
+            {
+                iconContent = EditorGUIUtility.IconContent("d_winbtn_mac_max");
+                labelContent.text = "BuildIndex: " + buildScene.buildIndex;
+                labelContent.tooltip = "This scene is in build settings and ENABLED.\nIt will be included in builds." +
+                                       readOnlyWarning;
+            }
+            // In build scenes and disabled
+            else
+            {
+                iconContent = EditorGUIUtility.IconContent("d_winbtn_mac_min");
+                labelContent.text = "BuildIndex: " + buildScene.buildIndex;
+                labelContent.tooltip =
+                    "This scene is in build settings and DISABLED.\nIt will be NOT included in builds.";
+            }
+
+            // Left status label
+            Rect buttonRect;
+            using (new EditorGUI.DisabledScope(readOnly))
+            {
+                var rect = EditorGUILayout.GetControlRect();
+                var labelRect = RectExtensions.AlignLeft(rect, EditorGUIUtility.labelWidth);
+                buttonRect = RectExtensions.AlignRight(rect, rect.width - EditorGUIUtility.labelWidth);
+
+                var iconRect = labelRect;
+                iconRect.width = iconContent.image.width + PAD_SIZE;
+                labelRect.width -= iconRect.width;
+                labelRect.x += iconRect.width;
+                EditorGUI.LabelField(iconRect, iconContent);
+                EditorGUI.LabelField(labelRect, labelContent);
+            }
+
+            // Right context buttons
+            buttonRect.width /= 3;
+
+            var tooltipMsg = "";
+            using (new EditorGUI.DisabledScope(readOnly))
+            {
+                // NOT in build settings
+                if (buildScene.buildIndex == -1)
+                {
+                    buttonRect.width *= 2;
+                    var addIndex = EditorBuildSettings.scenes.Length;
+                    tooltipMsg =
+                        "Add this scene to build settings. It will be appended to the end of the build scenes as buildIndex: " +
+                        addIndex + "." + readOnlyWarning;
+                    if (EllipsisButton(buttonRect, "Add...", "Add (buildIndex " + addIndex + ")",
+                            EditorStyles.miniButtonLeft,
+                            tooltipMsg))
+                        BuildUtils.AddBuildScene(buildScene);
+                    buttonRect.width /= 2;
+                    buttonRect.x += buttonRect.width;
+                }
+                // In build settings
+                else
+                {
+                    var isEnabled = buildScene.scene.enabled;
+                    var stateString = isEnabled ? "Disable" : "Enable";
+                    tooltipMsg = stateString + " this scene in build settings.\n" +
+                                 (isEnabled
+                                     ? "It will no longer be included in builds"
+                                     : "It will be included in builds") + "." +
+                                 readOnlyWarning;
+
+                    if (EllipsisButton(buttonRect, stateString, stateString + " In Build", EditorStyles.miniButtonLeft,
+                            tooltipMsg))
+                        BuildUtils.SetBuildSceneState(buildScene, !isEnabled);
+                    buttonRect.x += buttonRect.width;
+
+                    tooltipMsg =
+                        "Completely remove this scene from build settings.\nYou will need to add it again for it to be included in builds!" +
+                        readOnlyWarning;
+                    if (EllipsisButton(buttonRect, "Remove...", "Remove from Build", EditorStyles.miniButtonMid,
+                            tooltipMsg))
+                        BuildUtils.RemoveBuildScene(buildScene);
+                }
+            }
+
+            buttonRect.x += buttonRect.width;
+
+            tooltipMsg = "Open the 'Build Settings' Window for managing scenes." + readOnlyWarning;
+            if (EllipsisButton(buttonRect, "Settings", "Build Settings", EditorStyles.miniButtonRight, tooltipMsg))
+            {
+                BuildUtils.OpenBuildSettings();
+            }
+        }
+
+        public bool EllipsisButton(Rect position, string msgShort, string msgLong, GUIStyle style,
+            string tooltip = null)
+        {
+            var content = new GUIContent(msgLong) {tooltip = tooltip};
+
+            var longWidth = style.CalcSize(content).x;
+            if (longWidth > position.width) content.text = msgShort;
+
+            return GUI.Button(position, content, style);
+        }
+    }
+}

--- a/Assets/GUIUtils/Editor/Drawers/SceneReferenceDrawer.cs.meta
+++ b/Assets/GUIUtils/Editor/Drawers/SceneReferenceDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ce128bab257305b408be65f2753f4267
+timeCreated: 1613385878

--- a/Assets/GUIUtils/Editor/Drawers/SerializableTupleCollectionDrawer.cs
+++ b/Assets/GUIUtils/Editor/Drawers/SerializableTupleCollectionDrawer.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 using UnityEditor;
 using UnityEditorInternal;
 
-namespace Rhinox.Lightspeed.Editor
+namespace Rhinox.GUIUtils.Editor
 {
     [CustomPropertyDrawer(typeof(SerializableTupleCollection), true)]
     public class SerializableTupleCollectionDrawer : PropertyDrawer

--- a/Assets/GUIUtils/Editor/Drawers/SerializableTupleCollectionDrawer.cs
+++ b/Assets/GUIUtils/Editor/Drawers/SerializableTupleCollectionDrawer.cs
@@ -1,0 +1,66 @@
+using Rhinox.Lightspeed.Collections;
+using UnityEngine;
+using UnityEditor;
+using UnityEditorInternal;
+
+namespace Rhinox.Lightspeed.Editor
+{
+    [CustomPropertyDrawer(typeof(SerializableTupleCollection), true)]
+    public class SerializableTupleCollectionDrawer : PropertyDrawer
+    {
+        private ReorderableList _list;
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            if (_list == null)
+            {
+                var listProp = property.FindPropertyRelative("list");
+                _list = new ReorderableList(property.serializedObject, listProp, true, false, true, true);
+                _list.drawElementCallback = DrawListItems;
+            }
+
+            var firstLine = position;
+            firstLine.height = EditorGUIUtility.singleLineHeight;
+            EditorGUI.PropertyField(firstLine, property, label);
+
+            if (property.isExpanded)
+            {
+                position.y += firstLine.height;
+
+                var prevLabelWidth = EditorGUIUtility.labelWidth;
+                EditorGUIUtility.labelWidth = 80;
+
+                _list.DoList(position);
+
+                EditorGUIUtility.labelWidth = prevLabelWidth;
+            }
+        }
+
+        void DrawListItems(Rect rect, int index, bool isActive, bool isFocused)
+        {
+            SerializedProperty element = _list.serializedProperty.GetArrayElementAtIndex(index); // The element in the list
+
+            var keyProp = element.FindPropertyRelative("Item1");
+            var contents = new GUIContent[] {GUIContent.none, new GUIContent(" => ")};
+
+            EditorGUI.MultiPropertyField(rect, contents, keyProp,
+                EditorGUI.BeginProperty(rect, new GUIContent($"Element {index}"), element));
+
+            EditorGUI.EndProperty();
+        }
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            if (property.isExpanded)
+            {
+                var listProp = property.FindPropertyRelative("list");
+                if (listProp.arraySize < 2)
+                    return EditorGUIUtility.singleLineHeight + 42f;
+                else
+                    return EditorGUIUtility.singleLineHeight + 21f * (listProp.arraySize + 1);
+            }
+            else
+                return EditorGUIUtility.singleLineHeight;
+        }
+    }
+}

--- a/Assets/GUIUtils/Editor/Drawers/SerializableTupleCollectionDrawer.cs.meta
+++ b/Assets/GUIUtils/Editor/Drawers/SerializableTupleCollectionDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cbe114760f4b9db4d99a8a718337320e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/GUIUtils/Editor/Editors/CustomSmartEditor.cs
+++ b/Assets/GUIUtils/Editor/Editors/CustomSmartEditor.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 namespace Rhinox.GUIUtils.Editor
 {
     [CustomEditor(typeof(MonoBehaviour), true)]
+    [CanEditMultipleObjects]
     public class CustomSmartEditor : UnityEditor.Editor
     {
         private DrawablePropertyView _propertyView;

--- a/Assets/GUIUtils/Editor/Editors/CustomSmartEditor.cs
+++ b/Assets/GUIUtils/Editor/Editors/CustomSmartEditor.cs
@@ -1,0 +1,52 @@
+﻿using Rhinox.GUIUtils.Attributes;
+using Rhinox.Lightspeed.Reflection;
+using UnityEditor;
+using UnityEngine;
+
+namespace Rhinox.GUIUtils.Editor
+{
+    [CustomEditor(typeof(MonoBehaviour), true)]
+    public class CustomSmartEditor : UnityEditor.Editor
+    {
+        private DrawablePropertyView _propertyView;
+
+        public override void OnInspectorGUI()
+        {
+            var attr = target.GetType().GetCustomAttribute<SmartFallbackDrawnAttribute>();
+            if (attr == null)
+            {
+                base.OnInspectorGUI();
+                return;
+            }
+
+            if (attr.AllowUnityIfAble)
+            {
+                int count = CountDrawnProperties(serializedObject);
+                if (count > 0)
+                {
+                    base.OnInspectorGUI();
+                    return;
+                }
+            }
+
+            if (_propertyView == null)
+                _propertyView = new DrawablePropertyView(serializedObject);
+            
+            _propertyView.DrawLayout();
+        }
+        
+        private static int CountDrawnProperties(SerializedObject obj)
+        {
+            SerializedProperty iterator = obj.GetIterator();
+            bool enterChildren = true;
+            int count = 0;
+            while (iterator.NextVisible(enterChildren))
+            {
+                count++;
+                enterChildren = false;
+            }
+
+            return count;
+        }
+    }
+}

--- a/Assets/GUIUtils/Editor/Editors/CustomSmartEditor.cs.meta
+++ b/Assets/GUIUtils/Editor/Editors/CustomSmartEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 79a081f280a64a98a0b3bedae95161d8
+timeCreated: 1678379701

--- a/Assets/GUIUtils/Editor/Extensions/SerializedObjectExtensions.cs
+++ b/Assets/GUIUtils/Editor/Extensions/SerializedObjectExtensions.cs
@@ -245,7 +245,7 @@ namespace Rhinox.GUIUtils.Editor
                                 Host = property,
                                 FieldInfo = field,
                                 SerializedProperty = null,
-                                OverrideDrawable = new DrawableHelpBox(warning, MessageType.Warning)
+                                OverrideDrawable = new DrawableHelpBox(warning, MessageType.Warning, field)
                             };
                             
                     }

--- a/Assets/GUIUtils/Editor/Extensions/SerializedObjectExtensions.cs
+++ b/Assets/GUIUtils/Editor/Extensions/SerializedObjectExtensions.cs
@@ -214,6 +214,9 @@ namespace Rhinox.GUIUtils.Editor
             var fields = type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).ToList();
             foreach (var field in fields)
             {
+                if (field.GetCustomAttribute<HideInInspector>() != null)
+                    continue;
+                
                 var fieldProperty = property.FindPropertyRelative(field.Name);
                 if (fieldProperty == null)
                 {
@@ -252,6 +255,9 @@ namespace Rhinox.GUIUtils.Editor
             var fields = type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).ToList();
             foreach (var field in fields)
             {
+                if (field.GetCustomAttribute<HideInInspector>() != null)
+                    continue;
+                
                 var fieldProperty = serializedObject.FindProperty(field.Name);
                 if (fieldProperty == null)
                 {

--- a/Assets/GUIUtils/Editor/Extensions/SerializedObjectExtensions.cs
+++ b/Assets/GUIUtils/Editor/Extensions/SerializedObjectExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using Rhinox.Lightspeed;
 using Rhinox.Lightspeed.Reflection;
 using Sirenix.OdinInspector;
 using UnityEditor;
@@ -316,7 +317,6 @@ namespace Rhinox.GUIUtils.Editor
             }
         }
         
-        
         private static bool ShouldDrawUnsupportedWarning(FieldInfo fieldInfo, out string warning)
         {
             var attr = fieldInfo.GetReturnType().GetCustomAttribute<UnitySupportWarningAttribute>();
@@ -326,15 +326,8 @@ namespace Rhinox.GUIUtils.Editor
                 return false;
             }
 
-            string unityVersionStr = Application.unityVersion;
-            int index = unityVersionStr.IndexOf("f", StringComparison.InvariantCultureIgnoreCase);
-            if (index != -1)
-                unityVersionStr = unityVersionStr.Substring(0, index);
-            
-            var currentSemanticVersion = new Version(unityVersionStr);
-            var minimumSupportedVersion = new Version(attr.Major, attr.Minor, 0);
-
-            if (minimumSupportedVersion > currentSemanticVersion)
+            var currentRuntimeVersion = Utility.GetCurrentUnityRuntime();
+            if (attr.Version > currentRuntimeVersion)
             {
                 warning = $"This SerializedObject contains a property ({fieldInfo.Name}) of type {fieldInfo.GetReturnType().Name} which is only properly supported from version {attr.VersionString} or higher.";
                 return true;

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
@@ -21,7 +21,7 @@ namespace Rhinox.GUIUtils.Editor
             if (field.FieldType.InheritsFrom(typeof(IList)))
                 drawable = new DrawableList(prop);
             else
-                drawable = new DrawableUnityProperty(prop);
+                drawable = new DrawableUnityProperty(prop, field);
 
             var propOrder = field.GetCustomAttribute<PropertyOrderAttribute>();
             if (propOrder != null)
@@ -73,7 +73,7 @@ namespace Rhinox.GUIUtils.Editor
             object instanceVal = property.GetValue();
             
             if (type == typeof(GameObject))
-                return new List<IOrderedDrawable>() {new DrawableUnityObject(instanceVal)};
+                return new List<IOrderedDrawable>() {new DrawableUnityObject(instanceVal, property.FindFieldInfo())};
             
             var visibleFields = property.EnumerateEditorVisibleFields();
             return DrawableMembersFor(instanceVal, type, visibleFields, depth);
@@ -135,7 +135,7 @@ namespace Rhinox.GUIUtils.Editor
             object instanceVal = obj.targetObject;
             
             if (type == typeof(GameObject))
-                return new List<IOrderedDrawable>() {new DrawableUnityObject(instanceVal)};
+                return new List<IOrderedDrawable>() {new DrawableUnityObject(instanceVal, null)};
             
             var visibleFields = obj.EnumerateEditorVisibleFields();
             return DrawableMembersFor(instanceVal, type, visibleFields, depth);
@@ -144,7 +144,7 @@ namespace Rhinox.GUIUtils.Editor
         public static List<IOrderedDrawable> CreateDrawableMembersFor(object instance, Type t)
         {
             if (t == typeof(GameObject))
-                return new List<IOrderedDrawable>() {new DrawableUnityObject(instance)};
+                return new List<IOrderedDrawable>() {new DrawableUnityObject(instance, null)};
             return CreateDrawableMembersFor(instance, t, 0);
         }
 

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
@@ -85,7 +85,11 @@ namespace Rhinox.GUIUtils.Editor
             foreach (var fieldData in visibleFields)
             {
                 IOrderedDrawable fieldDrawable = null;
-                if (!fieldData.IsSerialized)
+                if (fieldData.OverrideDrawable != null)
+                {
+                    fieldDrawable = fieldData.OverrideDrawable;
+                }
+                else if (!fieldData.IsSerialized)
                 {
                     var val = fieldData.FieldInfo.GetValue(instanceVal);
                     fieldDrawable = CreateCompositeMemberForInstance(val, depth, fieldData.FieldInfo);

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawableGroupingHelper.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawableGroupingHelper.cs
@@ -117,7 +117,33 @@ namespace Rhinox.GUIUtils.Editor
                 }
 
                 if (isTopLevel)
-                    finalList.Add(group);
+                {
+                    int finalIndex = -1;
+                    foreach (var node in group.EnumerateTree(true))
+                    {
+                        int index = drawables.IndexOf(node);
+                        if (index == -1 || (finalIndex != -1 && finalIndex < index))
+                            continue;
+                        finalIndex = index;
+                    }
+
+                    if (finalIndex == -1 || finalIndex > finalList.Count)
+                        finalList.Add(group);
+                    else
+                    {
+                        if (finalList.HasIndex(finalIndex))
+                        {
+                            var curElement = finalList[finalIndex];
+                            int curElementOriginalIndex = drawables.IndexOf(curElement);
+                            if (curElementOriginalIndex > finalIndex)
+                                finalList.Insert(finalIndex, group);
+                            else
+                                finalList.Insert(finalIndex + 1, group);
+                        }
+                        else
+                            finalList.Insert(finalIndex, group);
+                    }
+                }
             }
 
             // Return list

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
@@ -64,7 +64,7 @@ namespace Rhinox.GUIUtils.Editor
             var drawables = DrawableFactory.CreateDrawableMembersFor(obj, type);
 
             if (drawables.Count == 0 && obj is UnityEngine.Object unityObj)
-                drawables.Add(new DrawableUnityObject(unityObj));
+                drawables.Add(new DrawableUnityObject(unityObj, null));
 
             if (!drawables.IsNullOrEmpty())
             {

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/BaseEntityDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/BaseEntityDrawable.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
@@ -9,12 +11,29 @@ namespace Rhinox.GUIUtils.Editor
     public abstract class BaseEntityDrawable : BaseDrawable
     {
         protected readonly object _targetObj;
+        private readonly MemberInfo _memberInfo;
 
         protected override string LabelString => _targetObj != null ? _targetObj.GetType().Name : null;
+
+        public override ICollection<TAttribute> GetDrawableAttributes<TAttribute>()
+        {
+            if (_memberInfo != null)
+            {
+                return _memberInfo.GetCustomAttributes<TAttribute>().ToArray();
+            }
+            return base.GetDrawableAttributes<TAttribute>();
+        }
 
         protected BaseEntityDrawable(object obj)
         {
             _targetObj = obj;
+            _memberInfo = null;
+        }
+        
+        protected BaseEntityDrawable(object obj, MemberInfo memberInfo)
+        {
+            _targetObj = obj;
+            _memberInfo = memberInfo;
         }
         
         protected override void DrawInner(GUIContent label)

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableButton.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableButton.cs
@@ -21,7 +21,7 @@ namespace Rhinox.GUIUtils.Editor
         private readonly ButtonAttribute _buttonAttr;
 
         public DrawableButton(object obj, MethodInfo method, ButtonAttribute buttonAttr)
-            : base(obj)
+            : base(obj, method)
         {
             _methodInfo = method;
             _buttonAttr = buttonAttr;

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableHelpBox.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableHelpBox.cs
@@ -1,0 +1,25 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace Rhinox.GUIUtils.Editor
+{
+    public class DrawableHelpBox : BaseEntityDrawable
+    {
+        public MessageType MsgType { get; }
+        
+        public DrawableHelpBox(string obj, MessageType type) : base(obj)
+        {
+            MsgType = type;
+        }
+        
+        protected override void Draw(object target)
+        {
+            EditorGUILayout.HelpBox((string)target, MsgType);
+        }
+
+        protected override void Draw(Rect rect, object target)
+        {
+            EditorGUI.HelpBox(rect, (string)target, MsgType);
+        }
+    }
+}

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableHelpBox.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableHelpBox.cs
@@ -1,4 +1,5 @@
-﻿using UnityEditor;
+﻿using System.Reflection;
+using UnityEditor;
 using UnityEngine;
 
 namespace Rhinox.GUIUtils.Editor
@@ -7,7 +8,7 @@ namespace Rhinox.GUIUtils.Editor
     {
         public MessageType MsgType { get; }
         
-        public DrawableHelpBox(string obj, MessageType type) : base(obj)
+        public DrawableHelpBox(string obj, MessageType type, FieldInfo fieldInfo = null) : base(obj, fieldInfo)
         {
             MsgType = type;
         }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableHelpBox.cs.meta
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableHelpBox.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cfa5882135ae4b0cb25385465f34557b
+timeCreated: 1678381920

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableList.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableList.cs
@@ -96,7 +96,7 @@ namespace Rhinox.GUIUtils.Editor
         }
 
         public DrawableList(object containerInstance, MemberInfo memberInfo)
-            : base(null)
+            : base(null, memberInfo)
         {
             if (containerInstance == null) throw new ArgumentNullException(nameof(containerInstance));
             _listProperty = null;

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableUnityObject.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableUnityObject.cs
@@ -1,12 +1,13 @@
-﻿using UnityEditor;
+﻿using System.Reflection;
+using UnityEditor;
 using UnityEngine;
 
 namespace Rhinox.GUIUtils.Editor
 {
     public class DrawableUnityObject : BaseEntityDrawable
     {
-        public DrawableUnityObject(object obj) 
-            : base(obj)
+        public DrawableUnityObject(object obj, MemberInfo info = null) 
+            : base(obj, info)
         {
         }
 

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableUnityProperty.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableUnityProperty.cs
@@ -1,4 +1,5 @@
-﻿using UnityEditor;
+﻿using System.Reflection;
+using UnityEditor;
 using UnityEngine;
 
 namespace Rhinox.GUIUtils.Editor
@@ -8,8 +9,8 @@ namespace Rhinox.GUIUtils.Editor
         protected override string LabelString =>
             _targetObj != null ? ((SerializedProperty) _targetObj).displayName : null;
 
-        public DrawableUnityProperty(SerializedProperty prop)
-            : base(prop)
+        public DrawableUnityProperty(SerializedProperty prop, MemberInfo memberInfo = null)
+            : base(prop, memberInfo)
         {
         }
         

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Members/CompositeDrawableMember.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Members/CompositeDrawableMember.cs
@@ -45,23 +45,27 @@ namespace Rhinox.GUIUtils.Editor
         public IReadOnlyCollection<IOrderedDrawable> Children => _drawableMemberChildren != null ? 
             _drawableMemberChildren : (IReadOnlyCollection<IOrderedDrawable>)Array.Empty<IOrderedDrawable>();
 
-        public IOrderedDrawable FirstOrDefault(Func<IOrderedDrawable, bool> func = null)
+        
+        /// <summary>
+        /// DFS
+        /// </summary>
+        /// <returns></returns>
+        public IEnumerable<IOrderedDrawable> EnumerateTree(bool onlyLeaves = false)
         {
-            if (func == null)
-                return Children.FirstOrDefault();
-
             foreach (var child in Children)
             {
                 if (child is CompositeDrawableMember compositeChild)
                 {
-                    return compositeChild.FirstOrDefault(func);
+                    if (!onlyLeaves)
+                        yield return child;
+                    foreach (var grandChild in compositeChild.EnumerateTree())
+                        yield return grandChild;
                 }
-
-                if (func.Invoke(child))
-                    return child;
+                else
+                {
+                    yield return child;
+                }
             }
-
-            return null;
         }
 
         public static CompositeDrawableMember CreateFrom(PropertyGroupAttribute groupingAttr)

--- a/Assets/GUIUtils/Editor/Helpers/BuildUtils.cs
+++ b/Assets/GUIUtils/Editor/Helpers/BuildUtils.cs
@@ -1,0 +1,217 @@
+using System.Linq;
+using UnityEditor;
+using UnityEditor.VersionControl;
+using UnityEngine;
+
+// TODO: cleanup class
+namespace Rhinox.GUIUtils.Editor
+{
+    /// <summary>
+    /// Various BuildSettings interactions
+    /// </summary>
+    public static class BuildUtils
+    {
+        // time in seconds that we have to wait before we query again when IsReadOnly() is called.
+        public static float minCheckWait = 3;
+
+        private static float lastTimeChecked;
+        private static bool cachedReadonlyVal = true;
+
+        /// <summary>
+        /// A small container for tracking scene data BuildSettings
+        /// </summary>
+        public struct BuildScene
+        {
+            public int buildIndex;
+            public GUID assetGUID;
+            public string assetPath;
+            public EditorBuildSettingsScene scene;
+        }
+
+        /// <summary>
+        /// Check if the build settings asset is readonly.
+        /// Caches value and only queries state a max of every 'minCheckWait' seconds.
+        /// </summary>
+        public static bool IsReadOnly()
+        {
+            var curTime = Time.realtimeSinceStartup;
+            var timeSinceLastCheck = curTime - lastTimeChecked;
+
+            if (!(timeSinceLastCheck > minCheckWait)) return cachedReadonlyVal;
+
+            lastTimeChecked = curTime;
+            cachedReadonlyVal = QueryBuildSettingsStatus();
+
+            return cachedReadonlyVal;
+        }
+
+        /// <summary>
+        /// A blocking call to the Version Control system to see if the build settings asset is readonly.
+        /// Use BuildSettingsIsReadOnly for version that caches the value for better responsivenes.
+        /// </summary>
+        private static bool QueryBuildSettingsStatus()
+        {
+            // If no version control provider, assume not readonly
+            if (!Provider.enabled) return false;
+
+            // If we cannot checkout, then assume we are not readonly
+            if (!Provider.hasCheckoutSupport) return false;
+
+            //// If offline (and are using a version control provider that requires checkout) we cannot edit.
+            //if (UnityEditor.VersionControl.Provider.onlineState == UnityEditor.VersionControl.OnlineState.Offline)
+            //    return true;
+
+            // Try to get status for file
+            var status = Provider.Status("ProjectSettings/EditorBuildSettings.asset", false);
+            status.Wait();
+
+            // If no status listed we can edit
+            if (status.assetList == null || status.assetList.Count != 1) return true;
+
+            // If is checked out, we can edit
+            return !status.assetList[0].IsState(Asset.States.CheckedOutLocal);
+        }
+
+        /// <summary>
+        /// For a given Scene Asset object reference, extract its build settings data, including buildIndex.
+        /// </summary>
+        public static BuildScene GetBuildScene(Object sceneObject)
+        {
+            var entry = new BuildScene
+            {
+                buildIndex = -1,
+                assetGUID = new GUID(string.Empty)
+            };
+
+            if (sceneObject as SceneAsset == null) return entry;
+
+            entry.assetPath = AssetDatabase.GetAssetPath(sceneObject);
+            entry.assetGUID = new GUID(AssetDatabase.AssetPathToGUID(entry.assetPath));
+
+            var scenes = EditorBuildSettings.scenes;
+            for (var index = 0; index < scenes.Length; ++index)
+            {
+                if (!entry.assetGUID.Equals(scenes[index].guid)) continue;
+
+                entry.scene = scenes[index];
+                entry.buildIndex = index;
+                return entry;
+            }
+
+            return entry;
+        }
+
+        /// <summary>
+        /// Enable/Disable a given scene in the buildSettings
+        /// </summary>
+        public static void SetBuildSceneState(BuildScene buildScene, bool enabled)
+        {
+            var modified = false;
+            var scenesToModify = EditorBuildSettings.scenes;
+            foreach (var curScene in scenesToModify.Where(curScene => curScene.guid.Equals(buildScene.assetGUID)))
+            {
+                curScene.enabled = enabled;
+                modified = true;
+                break;
+            }
+
+            if (modified) EditorBuildSettings.scenes = scenesToModify;
+        }
+
+        /// <summary>
+        /// Display Dialog to add a scene to build settings
+        /// </summary>
+        public static void AddBuildScene(BuildScene buildScene, bool force = false, bool enabled = true)
+        {
+            if (force == false)
+            {
+                var selection = EditorUtility.DisplayDialogComplex(
+                    "Add Scene To Build",
+                    "You are about to add scene at " + buildScene.assetPath + " To the Build Settings.",
+                    "Add as Enabled", // option 0
+                    "Add as Disabled", // option 1
+                    "Cancel (do nothing)"); // option 2
+
+                switch (selection)
+                {
+                    case 0: // enabled
+                        enabled = true;
+                        break;
+                    case 1: // disabled
+                        enabled = false;
+                        break;
+                    default:
+                        //case 2: // cancel
+                        return;
+                }
+            }
+
+            var newScene = new EditorBuildSettingsScene(buildScene.assetGUID, enabled);
+            var tempScenes = EditorBuildSettings.scenes.ToList();
+            tempScenes.Add(newScene);
+            EditorBuildSettings.scenes = tempScenes.ToArray();
+        }
+
+        /// <summary>
+        /// Display Dialog to remove a scene from build settings (or just disable it)
+        /// </summary>
+        public static void RemoveBuildScene(BuildScene buildScene, bool force = false)
+        {
+            var onlyDisable = false;
+            if (force == false)
+            {
+                var selection = -1;
+
+                var title = "Remove Scene From Build";
+                var details =
+                    $"You are about to remove the following scene from build settings:\n    {buildScene.assetPath}\n    buildIndex: {buildScene.buildIndex}\n\nThis will modify build settings, but the scene asset will remain untouched.";
+                var confirm = "Remove From Build";
+                var alt = "Just Disable";
+                var cancel = "Cancel (do nothing)";
+
+                if (buildScene.scene.enabled)
+                {
+                    details += "\n\nIf you want, you can also just disable it instead.";
+                    selection = EditorUtility.DisplayDialogComplex(title, details, confirm, alt, cancel);
+                }
+                else
+                {
+                    selection = EditorUtility.DisplayDialog(title, details, confirm, cancel) ? 0 : 2;
+                }
+
+                switch (selection)
+                {
+                    case 0: // remove
+                        break;
+                    case 1: // disable
+                        onlyDisable = true;
+                        break;
+                    default:
+                        //case 2: // cancel
+                        return;
+                }
+            }
+
+            // User chose to not remove, only disable the scene
+            if (onlyDisable)
+            {
+                SetBuildSceneState(buildScene, false);
+            }
+            // User chose to fully remove the scene from build settings
+            else
+            {
+                var tempScenes = EditorBuildSettings.scenes.ToList();
+                tempScenes.RemoveAll(scene => scene.guid.Equals(buildScene.assetGUID));
+                EditorBuildSettings.scenes = tempScenes.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Open the default Unity Build Settings window
+        /// </summary>
+        public static void OpenBuildSettings()
+        {
+            EditorWindow.GetWindow(typeof(BuildPlayerWindow));
+        }
+    }
+}

--- a/Assets/GUIUtils/Editor/Helpers/BuildUtils.cs.meta
+++ b/Assets/GUIUtils/Editor/Helpers/BuildUtils.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1746622c3d9b8424a8c2eef4ebe894f0
+timeCreated: 1613392518

--- a/Assets/GUIUtils/Editor/Helpers/CustomMenuTree.cs
+++ b/Assets/GUIUtils/Editor/Helpers/CustomMenuTree.cs
@@ -35,7 +35,6 @@ namespace Rhinox.GUIUtils.Editor
         public bool ShowGrouped = true;
 
         public string GroupingString = "/";
-        private bool _groupingIsDirty;
 
         public Rect VisibleRect { get; set; }
 
@@ -47,6 +46,7 @@ namespace Rhinox.GUIUtils.Editor
 #if !ODIN_INSPECTOR
         private List<HierarchyMenuItem> _groupingItems;
         private HierarchyMenuItem _rootItems;
+        private bool _groupingIsDirty;
 #endif
 
         public IReadOnlyList<IMenuItem> MenuItems => _items != null ? (IReadOnlyList<IMenuItem>) _items.AsReadOnly() : Array.Empty<IMenuItem>();        
@@ -269,9 +269,8 @@ namespace Rhinox.GUIUtils.Editor
             if (icon != null)
                 item.SetIcon(icon);
             _items.AddUnique(item);
-#endif
-            
             _groupingIsDirty = true;
+#endif
         }
 
         public void AddCustom(IMenuItem customItem)
@@ -281,7 +280,9 @@ namespace Rhinox.GUIUtils.Editor
             if (_items == null)
                 _items = new List<IMenuItem>(); ;
             _items.AddUnique(customItem);
+#if !ODIN_INSPECTOR
             _groupingIsDirty = true;
+#endif
         }
                
         

--- a/Assets/GUIUtils/NoOdin/Editor/Drawers/CustomCollectionDrawer.cs
+++ b/Assets/GUIUtils/NoOdin/Editor/Drawers/CustomCollectionDrawer.cs
@@ -12,7 +12,9 @@ using UnityEngine;
 
 namespace Rhinox.GUIUtils.NoOdin.Editor
 {
+#if UNITY_2020_1_OR_NEWER
     [CustomPropertyDrawer(typeof(CustomCollection<>), true)]
+#endif
     public class CustomCollectionDrawer<T, TArg> : GenericPropertyDrawer<T>
         where T : CustomCollection<TArg>, new()
     {

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/UnitySupportWarningDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/UnitySupportWarningDrawer.cs
@@ -6,7 +6,7 @@ using Sirenix.OdinInspector.Editor;
 using UnityEditor;
 using UnityEngine;
 
-namespace GUIUtils.Editor.Drawers
+namespace Rhinox.GUIUtils.Odin.Editor
 {
     public class UnitySupportWarningDrawer: OdinAttributeDrawer<UnitySupportWarningAttribute> 
     {

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/UnitySupportWarningDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/UnitySupportWarningDrawer.cs
@@ -10,6 +10,11 @@ namespace GUIUtils.Editor.Drawers
 {
     public class UnitySupportWarningDrawer: OdinAttributeDrawer<UnitySupportWarningAttribute> 
     {
+        protected override bool CanDrawAttributeProperty(InspectorProperty property)
+        {
+            return property.Info.TypeOfValue.IsGenericType;
+        }
+
         protected override void DrawPropertyLayout(GUIContent label)
         {
             base.DrawPropertyLayout(label);
@@ -24,7 +29,7 @@ namespace GUIUtils.Editor.Drawers
 
             if (minimumSupportedVersion > currentSemanticVersion)
             {
-                EditorGUILayout.HelpBox($"This GUI layout contains a property which is only properly supported from version {minimumSupportedVersion.ToString()} or higher.", MessageType.Warning);
+                EditorGUILayout.HelpBox($"This GUI layout contains a property ({Property.NiceName}) of type {Property.Info.TypeOfValue.Name} which is only properly supported from version {minimumSupportedVersion.ToString()} or higher.", MessageType.Warning);
             }
         }
     }

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/UnitySupportWarningDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/UnitySupportWarningDrawer.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Reflection;
+using Rhinox.GUIUtils.Attributes;
+using Rhinox.GUIUtils.Editor;
+using Sirenix.OdinInspector.Editor;
+using UnityEditor;
+using UnityEngine;
+
+namespace GUIUtils.Editor.Drawers
+{
+    public class UnitySupportWarningDrawer: OdinAttributeDrawer<UnitySupportWarningAttribute> 
+    {
+        protected override void DrawPropertyLayout(GUIContent label)
+        {
+            base.DrawPropertyLayout(label);
+
+            string unityVersionStr = Application.unityVersion;
+            int index = unityVersionStr.IndexOf("f");
+            if (index != -1)
+                unityVersionStr = unityVersionStr.Substring(0, index);
+            
+            var currentSemanticVersion = new Version(unityVersionStr);
+            var minimumSupportedVersion = new Version(Attribute.Major, Attribute.Minor, 0);
+
+            if (minimumSupportedVersion > currentSemanticVersion)
+            {
+                EditorGUILayout.HelpBox($"This GUI layout contains a property which is only properly supported from version {minimumSupportedVersion.ToString()} or higher.", MessageType.Warning);
+            }
+        }
+    }
+}

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/UnitySupportWarningDrawer.cs.meta
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/UnitySupportWarningDrawer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 660718b925b2435292418e720c698fab
+timeCreated: 1678291295

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Values/SerializableTypeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Values/SerializableTypeDrawer.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Rhinox.Lightspeed.Reflection;
+using Sirenix.OdinInspector;
+using Sirenix.OdinInspector.Editor;
+using Sirenix.Utilities;
+using Sirenix.Utilities.Editor;
+using UnityEditor;
+using UnityEngine;
+
+namespace Rhinox.GUIUtils.Odin.Editor
+{
+    [DrawerPriority(0, 0, 2003)]
+    public class SerializableTypeDrawer : OdinValueDrawer<SerializableType>
+    {
+        // Yeah it's ugly but eh
+        public class Null
+        {
+        }
+
+        protected string _typeMethod;
+        protected string _title;
+        protected string _error;
+        protected Type _baseType;
+
+        protected InspectorPropertyValueGetter<object> _rawGetter;
+
+        protected override void Initialize()
+        {
+            var typeFilter = Property.Attributes.OfType<TypeFilterAttribute>().FirstOrDefault();
+            if (typeFilter != null)
+            {
+                _typeMethod = typeFilter.MemberName;
+                _title = typeFilter.DropdownTitle;
+
+                _rawGetter = new InspectorPropertyValueGetter<object>(this.Property, _typeMethod);
+                _error = _rawGetter.ErrorMessage;
+            }
+        }
+
+        private IEnumerable<Type> ResolveRawGetter()
+        {
+            var result = _rawGetter.GetValue();
+            if (!(result is IEnumerable)) return Array.Empty<Type>();
+            return ((IEnumerable)result).Cast<object>().Select(x =>
+            {
+                switch (x)
+                {
+                    case Type t:
+                        return t;
+                    case SerializableType serializableType:
+                        return serializableType.Type;
+                    default:
+                        return null;
+                }
+            }).Where(x => x != null);
+        }
+
+        protected override void DrawPropertyLayout(GUIContent label)
+        {
+            if (_error != null)
+            {
+                SirenixEditorGUI.MessageBox(_error, MessageType.Error);
+                return;
+            }
+
+            var rect = EditorGUILayout.GetControlRect();
+
+            if (label != null)
+                rect = EditorGUI.PrefixLabel(rect, label);
+
+            var title = _title;
+            if (string.IsNullOrWhiteSpace(title)) title = ValueEntry.SmartValue?.Name;
+            if (string.IsNullOrWhiteSpace(title)) title = "<None>";
+
+            EditorGUI.BeginChangeCheck();
+            var types = TypeSelector.DrawSelectorDropdown(rect, GUIHelper.TempContent(title), CreateSelector);
+            if (EditorGUI.EndChangeCheck())
+            {
+                var t = types?.FirstOrDefault();
+                if (t == typeof(Null))
+                    t = null;
+                ValueEntry.SmartValue = new SerializableType(t);
+            }
+        }
+
+        private TypeSelector CreateSelector(Rect position)
+        {
+            TypeSelector selector = null;
+            if (_rawGetter != null)
+                selector = new TypeSelector(ResolveRawGetter(), false);
+            else if (_baseType != null)
+                selector = new TypeSelector(ReflectionUtility.GetTypesInheritingFrom(_baseType), false);
+            else
+                selector = new TypeSelector(AssemblyTypeFlags.All, false);
+
+            Type nullType = typeof(Null);
+            selector.SelectionTree.MenuItems.Insert(0, new OdinMenuItem(selector.SelectionTree, "None", nullType));
+
+            selector.SetSelection(ValueEntry.SmartValue);
+            selector.EnableSingleClickToSelect();
+            selector.FlattenTree = true;
+
+            selector.ShowInPopup(position);
+            return selector;
+        }
+    }
+}

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Values/SerializableTypeDrawer.cs.meta
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Values/SerializableTypeDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 561bcb9d2777bf04c8a703bdacb12cd5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/GUIUtils/package.json
+++ b/Assets/GUIUtils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.rhinox.open.guiutils",
   "displayName": "GUIUtils - Editor Graphical UI Extensions",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "unity": "2019.4",
   "description": "GUI Utils for Unity projects, mostly Editor extensions. (Optional Odin extensions)",
   "keywords": [
@@ -10,7 +10,7 @@
   ],
   "category": "Unity",
   "dependencies": {
-    "com.rhinox.open.lightspeed": "1.3.1"
+    "com.rhinox.open.lightspeed": "1.4.0"
   },
   "repository": {
     "type": "git",

--- a/Assets/Tests/EditorTest.cs
+++ b/Assets/Tests/EditorTest.cs
@@ -59,7 +59,7 @@ public class EditorTest : MonoBehaviour
 
     [DrawAsUnityGeneric]
     public GenericTest TestList;
-    [DrawAsUnityGeneric]
+    [DrawAsUnityGeneric, Tooltip("Doesn't work pre-2020")]
     public ToggleableList<int> TestList2;
     
     [DrawAsUnityGeneric]

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -10,7 +10,7 @@
     }
   ],
   "dependencies": {
-    "com.rhinox.open.lightspeed": "1.3.1",
+    "com.rhinox.open.lightspeed": "1.4.0",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.ide.rider": "1.2.1",
     "com.unity.ide.visualstudio": "2.0.11",


### PR DESCRIPTION
### Added
- SmartFallbackDrawnAttribute: Draws a MonoBehaviour with the custom DrawablePropertyView of GUIUtils (CustomSmartEditor)
- SceneReferenceDrawer: Drawer code for SceneReferenceData object
- SerializableTupleCollectionDrawer: Drawer code for SerializableTupleCollection
- Added support for UnitySupportWarningAttribute when drawing through DrawablePropertyView
- DrawableHelpBox (Drawable entity for adding help boxes in custom GUIs using DrawablePropertyView)
- EnumerateTree method on CompositeDrawableMember
- BuildUtils: To enumerate and change the currently selected settings in the build window

### Modified
- Drawable entities now support attributes where field infos can be found through reflection (DrawablePropertyView)
- Cleaned up compiler warnings

### Fixed
- Sorting of grouped drawables in DrawablePropertyView now works correctly 

### Removed
- FirstOrDefault method on CompositeDrawableMember (use EnumerateTree().FirstOrDefault() instead)

## Odin Only
### Added
- SerializableTypeDrawer: for drawing SerializableType object (moved from Lightspeed)
- UnitySupportWarningDrawer: Added support for UnitySupportWarningAttribute drawing with OdinAttributeDrawer