### PR TITLE
Ftr/fix buttongroups

### DIFF
--- a/Assets/GUIUtils/Editor/Editors/CustomSmartEditor.cs
+++ b/Assets/GUIUtils/Editor/Editors/CustomSmartEditor.cs
@@ -1,4 +1,5 @@
-﻿using Rhinox.GUIUtils.Attributes;
+﻿using System;
+using Rhinox.GUIUtils.Attributes;
 using Rhinox.Lightspeed.Reflection;
 using UnityEditor;
 using UnityEngine;
@@ -7,9 +8,10 @@ namespace Rhinox.GUIUtils.Editor
 {
     [CustomEditor(typeof(MonoBehaviour), true)]
     [CanEditMultipleObjects]
-    public class CustomSmartEditor : UnityEditor.Editor
+    public class CustomSmartEditor : UnityEditor.Editor, IRepaintRequestHandler
     {
         private DrawablePropertyView _propertyView;
+        private IRepaintRequest _target;
 
         public override void OnInspectorGUI()
         {
@@ -34,6 +36,16 @@ namespace Rhinox.GUIUtils.Editor
                 _propertyView = new DrawablePropertyView(serializedObject);
             
             _propertyView.DrawLayout();
+
+            if (_propertyView.ShouldRepaint)
+            {
+                Debug.LogError($"Should repaint now! {DateTime.Now.ToLongTimeString()}");
+                if (_target != null)
+                    _target.RequestRepaint();
+                else
+                    Repaint();
+                _propertyView.MarkAsRepainted();
+            }
         }
         
         private static int CountDrawnProperties(SerializedObject obj)
@@ -48,6 +60,11 @@ namespace Rhinox.GUIUtils.Editor
             }
 
             return count;
+        }
+
+        public void UpdateRequestTarget(IRepaintRequest target)
+        {
+            _target = target;
         }
     }
 }

--- a/Assets/GUIUtils/Editor/Editors/IRepaintRequest.cs
+++ b/Assets/GUIUtils/Editor/Editors/IRepaintRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace Rhinox.GUIUtils.Editor
+{
+    public interface IRepaintRequest
+    {
+        void RequestRepaint();
+    }
+}

--- a/Assets/GUIUtils/Editor/Editors/IRepaintRequest.cs.meta
+++ b/Assets/GUIUtils/Editor/Editors/IRepaintRequest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3e0bdea97de34a6ba421ee6a018f942b
+timeCreated: 1680619959

--- a/Assets/GUIUtils/Editor/Editors/IRepaintRequestHandler.cs
+++ b/Assets/GUIUtils/Editor/Editors/IRepaintRequestHandler.cs
@@ -1,0 +1,7 @@
+﻿namespace Rhinox.GUIUtils.Editor
+{
+    public interface IRepaintRequestHandler
+    {
+        void UpdateRequestTarget(IRepaintRequest target);
+    }
+}

--- a/Assets/GUIUtils/Editor/Editors/IRepaintRequestHandler.cs.meta
+++ b/Assets/GUIUtils/Editor/Editors/IRepaintRequestHandler.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0ae46eb94b404976b427e3c3aa037519
+timeCreated: 1680619861

--- a/Assets/GUIUtils/Editor/Extensions/SerializedObjectExtensions.cs
+++ b/Assets/GUIUtils/Editor/Extensions/SerializedObjectExtensions.cs
@@ -186,6 +186,12 @@ namespace Rhinox.GUIUtils.Editor
             System.Reflection.FieldInfo fi = FindFieldInfo(property);
             return fi.GetCustomAttribute(typeof(T)) as T;
         }
+
+        public static IEnumerable<Attribute> GetAttributes(this SerializedProperty property)
+        {
+            System.Reflection.FieldInfo fi = FindFieldInfo(property);
+            return fi.GetCustomAttributes();
+        }
         
         public static T GetAttributeOrCreate<T>(this SerializedProperty property) where T : Attribute, new()
         {

--- a/Assets/GUIUtils/Editor/GUI/Data/List/BetterReorderableList.cs
+++ b/Assets/GUIUtils/Editor/GUI/Data/List/BetterReorderableList.cs
@@ -754,7 +754,12 @@ namespace Rhinox.GUIUtils.Editor
                         Debug.LogError((object) ("Cannot add element. Type " + elementType.ToString() +
                                                  " has no default constructor. Implement a default constructor or implement your own add behaviour."));
                     else if (elementType != null)
-                        list.index = list.list.Add(Activator.CreateInstance(elementType));
+                    {
+                        if (elementType.InheritsFrom<UnityEngine.Object>())
+                            list.index = list.list.Add(null);
+                        else
+                            list.index = list.list.Add(Activator.CreateInstance(elementType));
+                    }
                     else
                         Debug.LogError((object) "Cannot add element of type Null.");
                 }

--- a/Assets/GUIUtils/Editor/GUI/Data/List/BetterReorderableList.cs
+++ b/Assets/GUIUtils/Editor/GUI/Data/List/BetterReorderableList.cs
@@ -141,7 +141,7 @@ namespace Rhinox.GUIUtils.Editor
             set => m_ActiveElement = value;
         }
 
-        private float listElementTopPadding => headerHeight > 5.0 ? 4f : 1f;
+        private float listElementTopPadding => CustomGUIUtility.Padding;
 
         public bool draggable
         {
@@ -646,6 +646,8 @@ namespace Rhinox.GUIUtils.Editor
             public GUIContent iconToolbarMinus =
                 EditorGUIUtility.TrIconContent("Toolbar Minus", "Remove selection from list");
 
+            private readonly Color altColor = new Color(0.29f, 0.29f, 0.29f, 1.0f);
+
             public readonly GUIStyle draggingHandle = (GUIStyle) "RL DragHandle";
             public readonly GUIStyle headerBackground = (GUIStyle) "RL Header";
             private readonly GUIStyle emptyHeaderBackground = (GUIStyle) "RL Empty Header";
@@ -653,31 +655,16 @@ namespace Rhinox.GUIUtils.Editor
             public readonly GUIStyle boxBackground = (GUIStyle) "RL Background";
             public readonly GUIStyle preButton = (GUIStyle) "RL FooterButton";
             public readonly GUIStyle elementBackground = (GUIStyle) "RL Element";
-            private GUIStyle _altBackground;
-            private Texture _altBackgroundNormalTex;
+            private GUIStyle _altElementBackground;
             public GUIStyle altElementBackground {
                 get
                 {
-                    Color c = new Color(0.29f, 0.29f, 0.29f, 1.0f);
-                    if (_altBackground == null)
-                    {
-                        var style = (GUIStyle) "RL Element";
-                        style = new GUIStyle(style);
-                        style.name = "RL Element Alt Style";
-                        _altBackground = style;
-                    }
-
-                    if (_altBackgroundNormalTex == null)
-                    { 
-                        var backgroundColor = _altBackground.normal.background;
-                        var altTex = backgroundColor != null ?
-                            MakeTex(backgroundColor.width, backgroundColor.height, c) : 
-                            MakeTex(1, 1, c);
-                        _altBackgroundNormalTex = altTex;
-                        _altBackground.normal.background = altTex;
-                    }
-
-                    return _altBackground;
+                    
+                    if (_altElementBackground != null) return _altElementBackground;
+                    _altElementBackground = new GUIStyle("RL Element");
+                    _altElementBackground.normal.background = Utility.GetColorTexture(altColor);
+                    _altElementBackground.onActive = elementBackground.onActive;
+                    return _altElementBackground;
                 }
             }
             public const int padding = 6;

--- a/Assets/GUIUtils/Editor/GUI/Data/List/PageableReorderableList.cs
+++ b/Assets/GUIUtils/Editor/GUI/Data/List/PageableReorderableList.cs
@@ -164,7 +164,7 @@ namespace Rhinox.GUIUtils.Editor
                     this.index = elementIndex + _drawPageIndex * MaxItemsPerPage;
                     s_Defaults.OnRemoveElement(this);
                     onChangedCallback?.Invoke(this);
-                    if (_drawPageIndex * MaxItemsPerPage >= this.count)
+                    if (_drawPageIndex * MaxItemsPerPage >= this.count && _drawPageIndex > 0)
                         --_drawPageIndex;
                 }
             }

--- a/Assets/GUIUtils/Editor/GUI/Data/List/PageableReorderableList.cs
+++ b/Assets/GUIUtils/Editor/GUI/Data/List/PageableReorderableList.cs
@@ -54,12 +54,12 @@ namespace Rhinox.GUIUtils.Editor
             MaxItemsPerPage = DEFAULT_ITEMS_PER_PAGE;
         }
 
-        public PageableReorderableList(object containerInstance, MemberInfo memberInfo, 
+        public PageableReorderableList(GenericMemberEntry entry, 
             bool draggable = true, bool displayHeader = true, bool displayAddButton = true, bool displayRemoveButton = true)
-            : base(memberInfo.GetValue(containerInstance) as IList, draggable, displayHeader, displayAddButton, displayRemoveButton)
+            : base(entry.GetSmartValue<IList>(), draggable, displayHeader, displayAddButton, displayRemoveButton)
         {
             MaxItemsPerPage = DEFAULT_ITEMS_PER_PAGE;
-            CustomTitle = memberInfo.Name;
+            CustomTitle = entry.NiceName;
         }
 
         protected override void InitList(SerializedObject serializedObject, SerializedProperty elements, IList elementList, bool draggable,
@@ -108,20 +108,20 @@ namespace Rhinox.GUIUtils.Editor
                 var buttonsRect = multiPageRect.AlignRight(multiPageRect.width * 0.6f);
                 var leftButtonRect = buttonsRect.AlignLeft(buttonsRect.width * 0.5f);
                 var rightButtonRect = buttonsRect.AlignRight(buttonsRect.width * 0.5f);
-                EditorGUI.BeginDisabledGroup(_drawPageIndex <= 0);
+                var wasEnabled = GUI.enabled;
+                GUI.enabled = _drawPageIndex <= 0;
                 if (GUI.Button(leftButtonRect, "<"))
                 {
                     if (_drawPageIndex > 0)
                         --_drawPageIndex;
                 }
-                EditorGUI.EndDisabledGroup();
-                EditorGUI.BeginDisabledGroup(_drawPageIndex >= maxPagesCount - 1);
+                GUI.enabled = _drawPageIndex >= maxPagesCount - 1;
                 if (GUI.Button(rightButtonRect, ">"))
                 {
                     if (_drawPageIndex < maxPagesCount - 1)
                         ++_drawPageIndex;
                 }
-                EditorGUI.EndDisabledGroup();
+                GUI.enabled = wasEnabled;
             }
         }
 

--- a/Assets/GUIUtils/Editor/GUI/Data/List/PageableReorderableList.cs
+++ b/Assets/GUIUtils/Editor/GUI/Data/List/PageableReorderableList.cs
@@ -109,13 +109,13 @@ namespace Rhinox.GUIUtils.Editor
                 var leftButtonRect = buttonsRect.AlignLeft(buttonsRect.width * 0.5f);
                 var rightButtonRect = buttonsRect.AlignRight(buttonsRect.width * 0.5f);
                 var wasEnabled = GUI.enabled;
-                GUI.enabled = _drawPageIndex <= 0;
+                GUI.enabled = _drawPageIndex > 0;
                 if (GUI.Button(leftButtonRect, "<"))
                 {
                     if (_drawPageIndex > 0)
                         --_drawPageIndex;
                 }
-                GUI.enabled = _drawPageIndex >= maxPagesCount - 1;
+                GUI.enabled = _drawPageIndex < maxPagesCount - 1;
                 if (GUI.Button(rightButtonRect, ">"))
                 {
                     if (_drawPageIndex < maxPagesCount - 1)

--- a/Assets/GUIUtils/Editor/GUI/Drawables/BaseDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/BaseDrawable.cs
@@ -54,11 +54,8 @@ namespace Rhinox.GUIUtils.Editor
             
             OnPostDraw();
         }
-        
-        protected virtual void DrawInner(GUIContent label, params GUILayoutOption[] options)
-            => DrawInner(label);
 
-        protected abstract void DrawInner(GUIContent label);
+        protected abstract void DrawInner(GUIContent label, params GUILayoutOption[] options);
         protected abstract void DrawInner(Rect rect, GUIContent label);
 
         /// <summary>

--- a/Assets/GUIUtils/Editor/GUI/Drawables/BaseDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/BaseDrawable.cs
@@ -23,6 +23,8 @@ namespace Rhinox.GUIUtils.Editor
             }
         }
 
+        public virtual bool ShouldRepaint { get; protected set; }
+
         public abstract string LabelString { get; }
         
         public object Host { get; protected set; }
@@ -69,6 +71,8 @@ namespace Rhinox.GUIUtils.Editor
                 Initialize();
                 _initialized = true;
             }
+
+            ShouldRepaint = false;
         }
         
         protected virtual void OnPostDraw()

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/BaseHorizontalGroupDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/BaseHorizontalGroupDrawable.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Rhinox.Lightspeed;
 using Sirenix.OdinInspector;
@@ -35,6 +36,8 @@ namespace Rhinox.GUIUtils.Editor
                 return;
             
             var width = _cachedRect.width;
+            // if (_size.MinSize > 0)
+            //     width = _size.MinSize;
             if (_size.PreferredSize > float.Epsilon)
                 width = _size.PreferredSize;
             if (_size.MaxSize > float.Epsilon)
@@ -42,7 +45,7 @@ namespace Rhinox.GUIUtils.Editor
 
             var widths = _widthResolver.Resolve(width, CustomGUIUtility.Padding);
 
-            // Debug.Log($"{this.Name} - Outer [{_size.MinSize} _{_size.PreferredSize}_ {_size.MaxSize}]");
+            Debug.Log($"{this.Name} - Outer [{_size.MinSize} _{_size.PreferredSize}_ {_size.MaxSize}]");
             var rect = EditorGUILayout.BeginHorizontal(CustomGUIStyles.Clean, GetLayoutOptions(_size));
 
             for (var i = 0; i < _drawableMemberChildren.Count; i++)
@@ -52,21 +55,21 @@ namespace Rhinox.GUIUtils.Editor
                     continue;
 
                 Rect innerRect = default;
-                // Debug.Log($"\tInner {widths[i]}");
-                GUILayoutOption[] options = new [] { GUILayout.Width(widths[i]) };
+                Debug.Log($"\tInner {widths[i]}");
+                GUILayoutOption[] options = widths[i] > 0 ? new [] { GUILayout.Width(widths[i]) } : Array.Empty<GUILayoutOption>();
                 innerRect = EditorGUILayout.BeginVertical(CustomGUIStyles.Clean, options);
 
                 childDrawable.Draw(childDrawable.Label, options);
 
                 EditorGUILayout.EndVertical();
-                // Debug.Log($"\tInner End {innerRect.width}");
+                Debug.Log($"\tInner End {innerRect.width}");
                 
                 if (i < _drawableMemberChildren.Count -1) // don't add padding for last item
                     GUILayout.Space(CustomGUIUtility.Padding);
             }
 
             EditorGUILayout.EndHorizontal();
-            // Debug.Log($"{this.Name} - Outer End {rect.width}");
+            Debug.Log($"{this.Name} - Outer End {rect.width}");
 
             if (rect.IsValid())
                 _cachedRect = rect;

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/BaseHorizontalGroupDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/BaseHorizontalGroupDrawable.cs
@@ -45,7 +45,7 @@ namespace Rhinox.GUIUtils.Editor
 
             var widths = _widthResolver.Resolve(width, CustomGUIUtility.Padding);
 
-            Debug.Log($"{this.Name} - Outer [{_size.MinSize} _{_size.PreferredSize}_ {_size.MaxSize}]");
+            // Debug.Log($"{this.Name} - Outer [{_size.MinSize} _{_size.PreferredSize}_ {_size.MaxSize}]");
             var rect = EditorGUILayout.BeginHorizontal(CustomGUIStyles.Clean, GetLayoutOptions(_size));
 
             for (var i = 0; i < _drawableMemberChildren.Count; i++)
@@ -55,21 +55,21 @@ namespace Rhinox.GUIUtils.Editor
                     continue;
 
                 Rect innerRect = default;
-                Debug.Log($"\tInner {widths[i]}");
-                GUILayoutOption[] options = widths[i] > 0 ? new [] { GUILayout.Width(widths[i]) } : Array.Empty<GUILayoutOption>();
-                innerRect = EditorGUILayout.BeginVertical(CustomGUIStyles.Clean, options);
+                // Debug.Log($"\tInner {widths[i]}");
+                GUILayoutOption[] childOptions = widths[i] > 0 ? new [] { GUILayout.Width(widths[i]) } : Array.Empty<GUILayoutOption>();
+                innerRect = EditorGUILayout.BeginVertical(CustomGUIStyles.Clean, childOptions);
 
-                childDrawable.Draw(childDrawable.Label, options);
+                childDrawable.Draw(childDrawable.Label, childOptions);
 
                 EditorGUILayout.EndVertical();
-                Debug.Log($"\tInner End {innerRect.width}");
+                // Debug.Log($"\tInner End {innerRect.width}");
                 
                 if (i < _drawableMemberChildren.Count -1) // don't add padding for last item
                     GUILayout.Space(CustomGUIUtility.Padding);
             }
 
             EditorGUILayout.EndHorizontal();
-            Debug.Log($"{this.Name} - Outer End {rect.width}");
+            // Debug.Log($"{this.Name} - Outer End {rect.width}");
 
             if (rect.IsValid())
                 _cachedRect = rect;

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/BaseHorizontalGroupDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/BaseHorizontalGroupDrawable.cs
@@ -11,7 +11,6 @@ namespace Rhinox.GUIUtils.Editor
     {
         protected readonly SizeResolver _widthResolver;
         protected Rect _cachedRect;
-        protected float _totalCachedWidth;
         
         public override float ElementHeight
         {

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/BaseHorizontalGroupDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/BaseHorizontalGroupDrawable.cs
@@ -1,0 +1,131 @@
+using System.Linq;
+using Rhinox.Lightspeed;
+using Sirenix.OdinInspector;
+using UnityEditor;
+using UnityEngine;
+
+namespace Rhinox.GUIUtils.Editor
+{
+    public abstract class BaseHorizontalGroupDrawable<T> : PropertyGroupDrawable<T>
+        where T : PropertyGroupAttribute
+    {
+        protected readonly SizeResolver _widthResolver;
+        protected Rect _cachedRect;
+        protected float _totalCachedWidth;
+        
+        public override float ElementHeight
+        {
+            get
+            {
+                if (Children == null)
+                    return EditorGUIUtility.singleLineHeight;
+                
+                return Children.Where(x => x.IsVisible).Max(x => x.ElementHeight);
+            }
+        }
+        
+        protected BaseHorizontalGroupDrawable(GroupedDrawable parent, string groupID, int order)
+            : base(parent, groupID, order)
+        {
+            _widthResolver = new SizeResolver();
+        }
+        
+        public override void Draw(GUIContent label)
+        {
+            if (_drawableMemberChildren == null)
+                return;
+            
+            var width = _cachedRect.width;
+            if (_size.PreferredSize > float.Epsilon)
+                width = _size.PreferredSize;
+            if (_size.MaxSize > float.Epsilon)
+                width = Mathf.Min(_size.MaxSize, width);
+
+            var widths = _widthResolver.Resolve(width, CustomGUIUtility.Padding);
+
+            // Debug.Log($"{this.Name} - Outer [{_size.MinSize} _{_size.PreferredSize}_ {_size.MaxSize}]");
+            var rect = EditorGUILayout.BeginHorizontal(CustomGUIStyles.Clean, GetLayoutOptions(_size));
+
+            for (var i = 0; i < _drawableMemberChildren.Count; i++)
+            {
+                var childDrawable = _drawableMemberChildren[i];
+                if (childDrawable == null || !childDrawable.IsVisible)
+                    continue;
+
+                Rect innerRect = default;
+                // Debug.Log($"\tInner {widths[i]}");
+                GUILayoutOption[] options = new [] { GUILayout.Width(widths[i]) };
+                innerRect = EditorGUILayout.BeginVertical(CustomGUIStyles.Clean, options);
+
+                childDrawable.Draw(childDrawable.Label, options);
+
+                EditorGUILayout.EndVertical();
+                // Debug.Log($"\tInner End {innerRect.width}");
+                
+                if (i < _drawableMemberChildren.Count -1) // don't add padding for last item
+                    GUILayout.Space(CustomGUIUtility.Padding);
+            }
+
+            EditorGUILayout.EndHorizontal();
+            // Debug.Log($"{this.Name} - Outer End {rect.width}");
+
+            if (rect.IsValid())
+                _cachedRect = rect;
+        }
+
+        public override void Draw(Rect rect, GUIContent label)
+        {
+            if (_drawableMemberChildren == null)
+                return;
+
+            if (rect.IsValid())
+                _cachedRect = rect;
+            
+            var widths = _widthResolver.Resolve(_cachedRect.width, CustomGUIUtility.Padding);
+            
+            Rect childRect = rect;
+            for (int i = 0; i < _drawableMemberChildren.Count; ++i)
+            {
+                var childDrawable = _drawableMemberChildren[i];
+                if (childDrawable == null || !childDrawable.IsVisible)
+                    continue;
+
+                childRect.width = widths[i];
+                childRect.height = childDrawable.ElementHeight;
+                childDrawable.Draw(childRect, childDrawable.Label);
+
+                childRect.x += childRect.width + CustomGUIUtility.Padding;
+            }
+        }
+
+        private void UpdateWidthManager()
+        {
+            _widthResolver.Clear();
+            _widthResolver.ClearCache();
+
+            foreach (var member in _drawableMemberChildren)
+            {
+                TryGetSizeInfo(member, out SizeInfo info);
+                _widthResolver.Add(info);
+            }
+        }
+        
+        private bool TryGetSizeInfo(IOrderedDrawable drawable, out SizeInfo info)
+        {
+            if (_sizeInfoByDrawable.ContainsKey(drawable))
+            {
+                info = _sizeInfoByDrawable[drawable];
+                return true;
+            }
+
+            info = SizeInfo.Empty;
+            return false;
+        }
+        
+        protected override void OnChildrenChanged()
+        {
+            base.OnChildrenChanged();        
+            UpdateWidthManager();
+        }
+    }
+}

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/BaseHorizontalGroupDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/BaseHorizontalGroupDrawable.cs
@@ -45,8 +45,7 @@ namespace Rhinox.GUIUtils.Editor
 
             var widths = _widthResolver.Resolve(width, CustomGUIUtility.Padding);
 
-            // Debug.Log($"{this.Name} - Outer [{_size.MinSize} _{_size.PreferredSize}_ {_size.MaxSize}]");
-            var rect = EditorGUILayout.BeginHorizontal(CustomGUIStyles.Clean, GetLayoutOptions(_size));
+            GUILayout.BeginHorizontal(CustomGUIStyles.Clean, GetLayoutOptions(_size));
 
             for (var i = 0; i < _drawableMemberChildren.Count; i++)
             {
@@ -54,25 +53,20 @@ namespace Rhinox.GUIUtils.Editor
                 if (childDrawable == null || !childDrawable.IsVisible)
                     continue;
 
-                Rect innerRect = default;
-                // Debug.Log($"\tInner {widths[i]}");
                 GUILayoutOption[] childOptions = widths[i] > 0 ? new [] { GUILayout.Width(widths[i]) } : Array.Empty<GUILayoutOption>();
-                innerRect = EditorGUILayout.BeginVertical(CustomGUIStyles.Clean, childOptions);
+                GUILayout.BeginVertical(CustomGUIStyles.Clean, childOptions);
 
                 childDrawable.Draw(childDrawable.Label, childOptions);
 
-                EditorGUILayout.EndVertical();
+                GUILayout.EndVertical();
                 // Debug.Log($"\tInner End {innerRect.width}");
                 
                 if (i < _drawableMemberChildren.Count -1) // don't add padding for last item
                     GUILayout.Space(CustomGUIUtility.Padding);
             }
 
-            EditorGUILayout.EndHorizontal();
+            GUILayout.EndHorizontal();
             // Debug.Log($"{this.Name} - Outer End {rect.width}");
-
-            if (rect.IsValid())
-                _cachedRect = rect;
         }
 
         public override void Draw(Rect rect, GUIContent label)

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/BaseHorizontalGroupDrawable.cs.meta
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/BaseHorizontalGroupDrawable.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e738286173b84c15a6bd7f62866a71d4
+timeCreated: 1680594939

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/BaseVerticalGroupDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/BaseVerticalGroupDrawable.cs
@@ -1,0 +1,74 @@
+using Sirenix.OdinInspector;
+using UnityEditor;
+using UnityEngine;
+
+namespace Rhinox.GUIUtils.Editor
+{
+    public abstract class BaseVerticalGroupDrawable<T> : PropertyGroupDrawable<T>
+        where T : PropertyGroupAttribute
+    {
+        public override float ElementHeight
+        {
+            get
+            {
+                if (Children == null)
+                    return EditorGUIUtility.singleLineHeight;
+                
+                float height = 0.0f;
+                foreach (var child in Children)
+                {
+                    if (!child.IsVisible)
+                        continue;
+                    if (height > 0)
+                        height += CustomGUIUtility.Padding;
+                    height += child.ElementHeight;
+                }
+                return height;
+            }
+        }
+        
+        protected BaseVerticalGroupDrawable(GroupedDrawable parent, string groupID, float order) : base(parent, groupID, order)
+        {
+        }
+        
+        public override void Draw(GUIContent label)
+        {
+            if (_drawableMemberChildren == null)
+                return;
+
+            var rect = EditorGUILayout.BeginVertical(CustomGUIStyles.Clean, GetLayoutOptions(_size));
+            
+            foreach (var childDrawable in _drawableMemberChildren)
+            {
+                if (childDrawable == null || !childDrawable.IsVisible)
+                    continue;
+                
+                childDrawable.Draw(childDrawable.Label);
+
+                GUILayout.Space(CustomGUIUtility.Padding); // padding
+            }
+            
+            EditorGUILayout.EndVertical();
+        }
+
+        public override void Draw(Rect rect, GUIContent label)
+        {
+            if (_drawableMemberChildren == null)
+                return;
+
+            Rect childRect = rect;
+            for (int i = 0; i < _drawableMemberChildren.Count; ++i)
+            {
+                var childDrawable = _drawableMemberChildren[i];
+                if (childDrawable == null || !childDrawable.IsVisible)
+                    continue;
+                
+                childRect.width = rect.width;
+                childRect.height = childDrawable.ElementHeight;
+                childDrawable.Draw(childRect, childDrawable.Label);
+                
+                childRect.y += childRect.height + CustomGUIUtility.Padding;
+            }
+        }
+    }
+}

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/BaseVerticalGroupDrawable.cs.meta
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/BaseVerticalGroupDrawable.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1e7e33bee16d438d95146140ae0d914f
+timeCreated: 1680594407

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/ButtonGroupDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/ButtonGroupDrawable.cs
@@ -1,0 +1,20 @@
+using Sirenix.OdinInspector;
+using UnityEngine;
+
+namespace Rhinox.GUIUtils.Editor
+{
+    public class ButtonGroupDrawable : BaseHorizontalGroupDrawable<ButtonGroupAttribute>
+    {
+        public ButtonGroupDrawable(GroupedDrawable parent, string groupID, int order) : base(parent, groupID, order)
+        {
+        }
+
+        protected override void ParseAttribute(IOrderedDrawable child, ButtonGroupAttribute attr)
+        {
+        }
+
+        protected override void ParseAttribute(ButtonGroupAttribute attr)
+        {
+        }
+    }
+}

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/ButtonGroupDrawable.cs.meta
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/ButtonGroupDrawable.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1dd71946812140abb43500049f5234d8
+timeCreated: 1680592788

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/CompositeDrawableMember.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/CompositeDrawableMember.cs
@@ -31,7 +31,7 @@ namespace Rhinox.GUIUtils.Editor
             Order = order;
         }
         
-        public IEnumerable<TAttribute> GetDrawableAttributes<TAttribute>() where TAttribute : Attribute
+        public virtual IEnumerable<TAttribute> GetDrawableAttributes<TAttribute>() where TAttribute : Attribute
         {
             if (_attributes == null)
                 return Array.Empty<TAttribute>();

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/CompositeDrawableMember.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/CompositeDrawableMember.cs
@@ -15,6 +15,9 @@ namespace Rhinox.GUIUtils.Editor
         public bool IsVisible => true;
         public virtual GUIContent Label => GUIContent.none;
 
+        public virtual bool ShouldRepaint =>
+            _drawableMemberChildren == null ? false : _drawableMemberChildren.Any(x => x.ShouldRepaint);
+
         protected readonly List<IOrderedDrawable> _drawableMemberChildren = new List<IOrderedDrawable>();
         protected readonly List<Attribute> _attributes = new List<Attribute>();
 

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/CompositeDrawableMember.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/CompositeDrawableMember.cs
@@ -10,13 +10,13 @@ namespace Rhinox.GUIUtils.Editor
     {
         public string Name { get; protected set; }
         public float Order { get; set; }
-        public object Host { get; }
+        public object Host { get; protected set; }
         
         public bool IsVisible => true;
         public virtual GUIContent Label => GUIContent.none;
 
         protected readonly List<IOrderedDrawable> _drawableMemberChildren = new List<IOrderedDrawable>();
-        private List<Attribute> _attributes;
+        protected readonly List<Attribute> _attributes = new List<Attribute>();
 
         public IReadOnlyCollection<IOrderedDrawable> Children
             => _drawableMemberChildren ?? (IReadOnlyCollection<IOrderedDrawable>) Array.Empty<IOrderedDrawable>();
@@ -38,10 +38,8 @@ namespace Rhinox.GUIUtils.Editor
             return _attributes.OfType<TAttribute>();
         }
 
-        public void AddAttribute(Attribute attribute)
+        public virtual void AddAttribute(Attribute attribute)
         {
-            if (_attributes == null)
-                _attributes = new List<Attribute>();
             _attributes.AddUnique(attribute);
         }
 

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/GroupedDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/GroupedDrawable.cs
@@ -192,6 +192,8 @@ namespace Rhinox.GUIUtils.Editor
                 if (groupIdParts.Count == 1)
                 {
                     nextGroup = GroupingHelper.CreateFrom(groupAttribute, this);
+                    if (nextGroup != null)
+                        nextGroup.AddAttribute(groupAttribute);
                     // We don't add them yet, add the group when it is used to preserve property order
                     // base.Add(nextGroup);
                     _subGroupsByName.Add(next, nextGroup);

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/GroupedDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/GroupedDrawable.cs
@@ -212,8 +212,7 @@ namespace Rhinox.GUIUtils.Editor
 
         public void EnsureSizeFits(SizeInfo size)
         {
-            size.MinSize = Mathf.Max(_size.MinSize, size.MinSize);
-            
+            // If the parent has a max size, make sure the child fits inside of it
             if (_size.MaxSize > 0)
             {
                 float width = _size.MaxSize;
@@ -221,6 +220,7 @@ namespace Rhinox.GUIUtils.Editor
                     size.MaxSize = width;
             }
             
+            // If the parent has a preferred size, make sure the child fits inside of it
             if (_size.PreferredSize > 0)
             {
                 float width = _size.PreferredSize;

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/GroupedDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/GroupedDrawable.cs
@@ -83,8 +83,13 @@ namespace Rhinox.GUIUtils.Editor
             // when this exceeds list count, we've gone through the entire list without resolving an attribute and we can give up
             int attempts = 0;
             var attributesQueue = new Queue<PropertyGroupAttribute>(groupAttributes);
-            while (attributesQueue.Any() && attributesQueue.Count > attempts)
+            while (attributesQueue.Any())
             {
+                if (attributesQueue.Count > attempts)
+                {
+                    Debug.LogError($"Could not find group '{attributesQueue.Peek().GroupName}'...");
+                    break;
+                }
                 // If we managed to get or create our group, reset attempts and remove our entry
                 if (TryGetOrCreateGroup(attributesQueue.Peek(), out GroupedDrawable group))
                 {

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/GroupedDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/GroupedDrawable.cs
@@ -85,7 +85,7 @@ namespace Rhinox.GUIUtils.Editor
             var attributesQueue = new Queue<PropertyGroupAttribute>(groupAttributes);
             while (attributesQueue.Any())
             {
-                if (attributesQueue.Count > attempts)
+                if (attributesQueue.Count < attempts)
                 {
                     Debug.LogError($"Could not find group '{attributesQueue.Peek().GroupName}'...");
                     break;

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/GroupedDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/GroupedDrawable.cs
@@ -212,6 +212,8 @@ namespace Rhinox.GUIUtils.Editor
 
         public void EnsureSizeFits(SizeInfo size)
         {
+            size.MinSize = Mathf.Max(_size.MinSize, size.MinSize);
+            
             if (_size.MaxSize > 0)
             {
                 float width = _size.MaxSize;

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/GroupedDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/GroupedDrawable.cs
@@ -161,8 +161,6 @@ namespace Rhinox.GUIUtils.Editor
 
         protected abstract void ParseAttribute(IOrderedDrawable child, PropertyGroupAttribute attr);
         
-        protected abstract void ParseAttribute(PropertyGroupAttribute attr);
-
         protected void SetOrder(float order)
         {
             Order = order;
@@ -179,7 +177,7 @@ namespace Rhinox.GUIUtils.Editor
             // if we've reached the final leaf, return ourselves and that we managed to find it
             if (groupIdParts.Count == 0)
             {
-                ParseAttribute(groupAttribute);
+                AddAttribute(groupAttribute);
                 finalGroup = this;
                 return true;
             }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/GroupingHelper.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/GroupingHelper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Rhinox.Lightspeed;
 using Sirenix.OdinInspector;
+using UnityEngine;
 
 namespace Rhinox.GUIUtils.Editor
 {
@@ -11,13 +12,22 @@ namespace Rhinox.GUIUtils.Editor
         
         public static GroupedDrawable CreateFrom(PropertyGroupAttribute groupingAttr, GroupedDrawable parent = null)
         {
-            if (groupingAttr is TitleGroupAttribute)
-                return new TitleGroupDrawable(parent, groupingAttr.GroupID, groupingAttr.Order);
-            
-            if (groupingAttr is HorizontalGroupAttribute || groupingAttr is ButtonGroupAttribute)
-                return new HorizontalGroupDrawable(parent, groupingAttr.GroupID, groupingAttr.Order);
+            switch (groupingAttr)
+            {
+                case ButtonGroupAttribute buttonGroupAttribute:
+                    return new ButtonGroupDrawable(parent, groupingAttr.GroupID, groupingAttr.Order);
+                case HorizontalGroupAttribute horizontalGroupAttribute:
+                    return new HorizontalGroupDrawable(parent, groupingAttr.GroupID, groupingAttr.Order);
+                case TitleGroupAttribute titleGroupAttribute:
+                    return new TitleGroupDrawable(parent, groupingAttr.GroupID, groupingAttr.Order);
+                case VerticalGroupAttribute verticalGroupAttribute:
+                    return new VerticalGroupDrawable(parent, groupingAttr.GroupID, groupingAttr.Order);
+                default:
+                    Debug.LogError($"Unimplemented Group type: {groupingAttr.GetType().Name}");
+                    break;
+            }
 
-            return new VerticalGroupDrawable(parent, groupingAttr.GroupID, groupingAttr.Order);
+            return null;
         }
 
         public static string[] SplitIntoParts(string groupId)

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/HorizontalGroupDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/HorizontalGroupDrawable.cs
@@ -1,183 +1,46 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Rhinox.Lightspeed;
 using Sirenix.OdinInspector;
-using UnityEditor;
-using UnityEngine;
 
 namespace Rhinox.GUIUtils.Editor
 {
-    public class HorizontalGroupDrawable : GroupedDrawable
+    public class HorizontalGroupDrawable : BaseHorizontalGroupDrawable<HorizontalGroupAttribute>
     {
-        public override float ElementHeight
-        {
-            get
-            {
-                if (Children == null)
-                    return EditorGUIUtility.singleLineHeight;
-                
-                return Children.Where(x => x.IsVisible).Max(x => x.ElementHeight);
-            }
-        }
-        
-        protected readonly SizeResolver _widthResolver;
-        private Rect _cachedRect;
-        private float _totalCachedWidth;
-
         public HorizontalGroupDrawable(GroupedDrawable parent, string groupID, int order)
             : base(parent, groupID, order)
         {
-            _widthResolver = new SizeResolver();
         }
         
-
-        public override void Draw(GUIContent label)
+        protected override void ParseAttribute(IOrderedDrawable child, HorizontalGroupAttribute attr)
         {
-            if (_drawableMemberChildren == null)
-                return;
-            
-            var width = _cachedRect.width;
-            if (_size.PreferredSize > float.Epsilon)
-                width = _size.PreferredSize;
-            if (_size.MaxSize > float.Epsilon)
-                width = Mathf.Min(_size.MaxSize, width);
-
-            var widths = _widthResolver.Resolve(width, CustomGUIUtility.Padding);
-
-            // Debug.Log($"{this.Name} - Outer [{_size.MinSize} _{_size.PreferredSize}_ {_size.MaxSize}]");
-            var rect = EditorGUILayout.BeginHorizontal(CustomGUIStyles.Clean, GetLayoutOptions(_size));
-
-            for (var i = 0; i < _drawableMemberChildren.Count; i++)
+            var info = new SizeInfo
             {
-                var childDrawable = _drawableMemberChildren[i];
-                if (childDrawable == null || !childDrawable.IsVisible)
-                    continue;
+                PreferredSize = attr.Width,
+                MaxSize = attr.MaxWidth,
+                MinSize = attr.MinWidth
+            };
 
-                Rect innerRect = default;
-                // Debug.Log($"\tInner {widths[i]}");
-                GUILayoutOption[] options = new [] { GUILayout.Width(widths[i]) };
-                innerRect = EditorGUILayout.BeginVertical(CustomGUIStyles.Clean, options);
+            EnsureSizeFits(info);
 
-                childDrawable.Draw(childDrawable.Label, options);
-
-                EditorGUILayout.EndVertical();
-                // Debug.Log($"\tInner End {innerRect.width}");
-                
-                if (i < _drawableMemberChildren.Count -1) // don't add padding for last item
-                    GUILayout.Space(CustomGUIUtility.Padding);
-            }
-
-            EditorGUILayout.EndHorizontal();
-            // Debug.Log($"{this.Name} - Outer End {rect.width}");
-
-            if (rect.IsValid())
-                _cachedRect = rect;
-        }
-
-        public override void Draw(Rect rect, GUIContent label)
-        {
-            if (_drawableMemberChildren == null)
-                return;
-
-            if (rect.IsValid())
-                _cachedRect = rect;
-            
-            var widths = _widthResolver.Resolve(_cachedRect.width, CustomGUIUtility.Padding);
-            
-            Rect childRect = rect;
-            for (int i = 0; i < _drawableMemberChildren.Count; ++i)
-            {
-                var childDrawable = _drawableMemberChildren[i];
-                if (childDrawable == null || !childDrawable.IsVisible)
-                    continue;
-
-                childRect.width = widths[i];
-                childRect.height = childDrawable.ElementHeight;
-                childDrawable.Draw(childRect, childDrawable.Label);
-
-                childRect.x += childRect.width + CustomGUIUtility.Padding;
-            }
-        }
-
-        private void UpdateWidthManager()
-        {
-            _widthResolver.Clear();
-            _widthResolver.ClearCache();
-
-            foreach (var member in _drawableMemberChildren)
-            {
-                TryGetSizeInfo(member, out SizeInfo info);
-                _widthResolver.Add(info);
-            }
-        }
-
-        private bool TryGetSizeInfo(IOrderedDrawable drawable, out SizeInfo info)
-        {
-            if (_sizeInfoByDrawable.ContainsKey(drawable))
-            {
-                info = _sizeInfoByDrawable[drawable];
-                return true;
-            }
-
-            info = SizeInfo.Empty;
-            return false;
+            _sizeInfoByDrawable.Add(child, info);
         }
         
-        protected override void ParseAttribute(IOrderedDrawable child, PropertyGroupAttribute attr)
+        protected override void ParseAttribute(HorizontalGroupAttribute attr)
         {
-            if (attr is HorizontalGroupAttribute groupAttribute)
-            {
-                // No need to trigger ParseAttribute -> should have happened already, but it can't hurt
-                ParseAttribute(groupAttribute);
-                
-                var info = new SizeInfo
-                {
-                    PreferredSize = groupAttribute.Width,
-                    MaxSize = groupAttribute.MaxWidth,
-                    MinSize = groupAttribute.MinWidth
-                };
-                
-                EnsureSizeFits(info);
-            
-                _sizeInfoByDrawable.Add(child, info);
-            }
-            else // incorrect attribute
-                throw new ArgumentException(nameof(attr));
-        }
+            SetOrder(attr.Order);
 
-        private readonly List<HorizontalGroupAttribute> _parsedAttributes = new List<HorizontalGroupAttribute>();
+            _size.MinSize = _parsedAttributes.Sum(x => x.Width > 0 ? x.Width : x.MinWidth);
+            if (_parsedAttributes.All(x => x.Width > 0))
+                _size.PreferredSize = _parsedAttributes.Sum(x => x.Width);
+            else
+                _size.PreferredSize = 0;
+            if (_parsedAttributes.All(x => x.Width > 0 || x.MaxWidth > 0))
+                _size.MaxSize = _parsedAttributes.Sum(x => x.Width > 0 ? x.Width : x.MaxWidth);
+            else
+                _size.MaxSize = 0;
 
-        protected override void ParseAttribute(PropertyGroupAttribute attr)
-        {
-            if (_parsedAttributes.Contains(attr))
-                return;
-            
-            if (attr is HorizontalGroupAttribute groupAttribute)
-            {
-                _parsedAttributes.Add(groupAttribute);
-                SetOrder(groupAttribute.Order);
-                
-                _size.MinSize = _parsedAttributes.Sum(x => x.Width > 0 ? x.Width : x.MinWidth);
-                if (_parsedAttributes.All(x => x.Width > 0))
-                    _size.PreferredSize = _parsedAttributes.Sum(x => x.Width);
-                else
-                    _size.PreferredSize = 0;
-                if (_parsedAttributes.All(x => x.Width > 0 || x.MaxWidth > 0))
-                    _size.MaxSize = _parsedAttributes.Sum(x => x.Width > 0 ? x.Width : x.MaxWidth);
-                else
-                    _size.MaxSize = 0;
-                
-                _parent?.EnsureSizeFits(_size);
-            }
-            else // incorrect attribute
-                throw new ArgumentException(nameof(attr));
-        }
-
-        protected override void OnChildrenChanged()
-        {
-            base.OnChildrenChanged();        
-            UpdateWidthManager();
+            _parent?.EnsureSizeFits(_size);
         }
     }
 }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/HorizontalGroupDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/HorizontalGroupDrawable.cs
@@ -30,13 +30,13 @@ namespace Rhinox.GUIUtils.Editor
         {
             SetOrder(attr.Order);
 
-            _size.MinSize = _parsedAttributes.Sum(x => x.Width > 0 ? x.Width : x.MinWidth);
-            if (_parsedAttributes.All(x => x.Width > 0))
-                _size.PreferredSize = _parsedAttributes.Sum(x => x.Width);
+            _size.MinSize = _groupAttributes.Sum(x => x.Width > 0 ? x.Width : x.MinWidth);
+            if (_groupAttributes.All(x => x.Width > 0))
+                _size.PreferredSize = _groupAttributes.Sum(x => x.Width);
             else
                 _size.PreferredSize = 0;
-            if (_parsedAttributes.All(x => x.Width > 0 || x.MaxWidth > 0))
-                _size.MaxSize = _parsedAttributes.Sum(x => x.Width > 0 ? x.Width : x.MaxWidth);
+            if (_groupAttributes.All(x => x.Width > 0 || x.MaxWidth > 0))
+                _size.MaxSize = _groupAttributes.Sum(x => x.Width > 0 ? x.Width : x.MaxWidth);
             else
                 _size.MaxSize = 0;
 

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/ObjectCompositeDrawableMember.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/ObjectCompositeDrawableMember.cs
@@ -27,8 +27,10 @@ namespace Rhinox.GUIUtils.Editor
                 return height;
             }
         }
-        
-        
+
+        public override bool ShouldRepaint => base.ShouldRepaint || (_innerDrawable != null ? _innerDrawable.ShouldRepaint : false);
+
+
         public ObjectCompositeDrawableMember(GenericMemberEntry entry, IOrderedDrawable contents, float order = 0)
             : this(entry.NiceName, contents, order)
         {

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/ObjectCompositeDrawableMember.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/ObjectCompositeDrawableMember.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using Rhinox.Lightspeed;
 using UnityEditor;
@@ -5,30 +6,40 @@ using UnityEngine;
 
 namespace Rhinox.GUIUtils.Editor
 {
-    public class ObjectCompositeDrawableMember : VerticalGroupDrawable
+    public class ObjectCompositeDrawableMember : CompositeDrawableMember
     {
-        private GUIContent _label;
-
         public override GUIContent Label => _label;
 
+        private GUIContent _label;
         private bool _hasLabel = false;
+        
+        private IOrderedDrawable _innerDrawable;
 
         public override float ElementHeight
         {
             get
             {
-                var height = base.ElementHeight;
+                var height = _innerDrawable.ElementHeight;
                 if (IsFoldout() && _hasLabel)
                     height += EditorGUIUtility.singleLineHeight + CustomGUIUtility.Padding;
                 return height;
             }
         }
-
-        public ObjectCompositeDrawableMember(string name, float order = 0)
-            : base(null, name, order)
+        
+        
+        public ObjectCompositeDrawableMember(GenericMemberEntry entry, IOrderedDrawable contents, float order = 0)
+            : this(entry.NiceName, contents, order)
+        {
+            Host = entry;
+        }
+        
+        public ObjectCompositeDrawableMember(string name, IOrderedDrawable contents, float order = 0)
+            : base(name, order)
         {
             _label = new GUIContent(name);
+            _innerDrawable = contents;
         }
+
 
         public override void Draw(GUIContent label)
         {
@@ -42,7 +53,7 @@ namespace Rhinox.GUIUtils.Editor
                 }
                 ++EditorGUI.indentLevel;
                 
-                base.Draw(GUIContent.none);
+                _innerDrawable.Draw(GUIContent.none);
                 
                 --EditorGUI.indentLevel;
             }
@@ -55,7 +66,7 @@ namespace Rhinox.GUIUtils.Editor
                 var indent = EditorGUI.indentLevel;
                 EditorGUI.indentLevel = 0;
                 
-                base.Draw(GUIContent.none);
+                _innerDrawable.Draw(GUIContent.none);
                 
                 EditorGUI.indentLevel = indent;
                 GUILayout.EndHorizontal();
@@ -87,7 +98,7 @@ namespace Rhinox.GUIUtils.Editor
                 rect = EditorGUI.PrefixLabel(rect, label);
             }
             
-            base.Draw(rect, GUIContent.none);
+            _innerDrawable.Draw(rect, GUIContent.none);
 
             EditorGUI.indentLevel = indentLevel;
         }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/ObjectCompositeDrawableMember.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/ObjectCompositeDrawableMember.cs
@@ -15,12 +15,14 @@ namespace Rhinox.GUIUtils.Editor
         
         private IOrderedDrawable _innerDrawable;
 
+        public bool IsFoldout => Children.Any(drawable => drawable.IsVisible);
+
         public override float ElementHeight
         {
             get
             {
                 var height = _innerDrawable.ElementHeight;
-                if (IsFoldout() && _hasLabel)
+                if (IsFoldout && _hasLabel)
                     height += EditorGUIUtility.singleLineHeight + CustomGUIUtility.Padding;
                 return height;
             }
@@ -36,16 +38,21 @@ namespace Rhinox.GUIUtils.Editor
         public ObjectCompositeDrawableMember(string name, IOrderedDrawable contents, float order = 0)
             : base(name, order)
         {
-            _label = new GUIContent(name);
+            if (name.IsNullOrEmpty())
+                _label = GUIContent.none;
+            else
+                _label = new GUIContent(name);
+            
             _innerDrawable = contents;
         }
 
 
         public override void Draw(GUIContent label)
         {
-            if (IsFoldout())
+            _hasLabel = label != GUIContent.none;
+
+            if (IsFoldout)
             {
-                _hasLabel = label != GUIContent.none;
                 if (_hasLabel)
                 {
                     GUILayout.Label(label);
@@ -59,9 +66,11 @@ namespace Rhinox.GUIUtils.Editor
             }
             else
             {
-                GUILayout.BeginHorizontal(GUILayout.ExpandWidth(true));
-
-                EditorGUILayout.PrefixLabel(label);
+                if (_hasLabel)
+                {
+                    GUILayout.BeginHorizontal(CustomGUIStyles.Clean);
+                    EditorGUILayout.PrefixLabel(label);
+                }
 
                 var indent = EditorGUI.indentLevel;
                 EditorGUI.indentLevel = 0;
@@ -69,16 +78,17 @@ namespace Rhinox.GUIUtils.Editor
                 _innerDrawable.Draw(GUIContent.none);
                 
                 EditorGUI.indentLevel = indent;
-                GUILayout.EndHorizontal();
+                
+                if (_hasLabel)
+                    GUILayout.EndHorizontal();
             }
         }
 
         public override void Draw(Rect rect, GUIContent label)
         {
-            bool isFoldout = IsFoldout();
             var indentLevel = EditorGUI.indentLevel;
             
-            if (isFoldout)
+            if (IsFoldout)
             {
                 _hasLabel = label != GUIContent.none;
                 if (_hasLabel)
@@ -101,22 +111,6 @@ namespace Rhinox.GUIUtils.Editor
             _innerDrawable.Draw(rect, GUIContent.none);
 
             EditorGUI.indentLevel = indentLevel;
-        }
-        
-        private bool IsFoldout()
-        {
-            int count = 0;
-            foreach (var drawable in Children)
-            {
-                // TODO drawable.IsVisible?
-                if (drawable is HideWrapper hiddenDrawable)
-                {
-                    if (!hiddenDrawable.ShouldDraw())
-                        continue;
-                }
-                ++count;
-            }
-            return count > 1;
         }
     }
 }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/PropertyGroupDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/PropertyGroupDrawable.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Sirenix.OdinInspector;
+
+namespace Rhinox.GUIUtils.Editor
+{
+    public abstract class PropertyGroupDrawable<T> : GroupedDrawable
+        where T : PropertyGroupAttribute
+    {
+        protected readonly List<T> _parsedAttributes = new List<T>();
+
+        protected PropertyGroupDrawable(GroupedDrawable parent, string groupID, float order) : base(parent, groupID, order)
+        {
+            
+        }
+        
+        protected T ValidateAttribute(PropertyGroupAttribute attr)
+        {
+            if (attr is T typedAttr)
+                return typedAttr;
+            
+            // incorrect attribute
+            throw new ArgumentException(nameof(attr), $"{GetType().Name} cannot parse attribute of type {attr.GetType().Name}");
+        }
+
+        protected override void ParseAttribute(IOrderedDrawable child, PropertyGroupAttribute attr)
+        {
+            var groupAttribute = ValidateAttribute(attr);
+
+            // No need to trigger ParseAttribute -> should have happened already, but it can't hurt
+            ParseAttribute(groupAttribute);
+            ParseAttribute(child, groupAttribute);
+        }
+
+        protected abstract void ParseAttribute(IOrderedDrawable child, T attr);
+
+        
+        protected override void ParseAttribute(PropertyGroupAttribute attr)
+        {
+            if (_parsedAttributes.Contains(attr))
+                return;
+
+            var groupAttribute = ValidateAttribute(attr);
+            _parsedAttributes.Add(groupAttribute);
+            ParseAttribute(groupAttribute);
+        }
+
+        protected abstract void ParseAttribute(T attr);
+
+    }
+}

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/PropertyGroupDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/PropertyGroupDrawable.cs
@@ -45,8 +45,12 @@ namespace Rhinox.GUIUtils.Editor
             _parsedAttributes.Add(groupAttribute);
             ParseAttribute(groupAttribute);
         }
-
+        
         protected abstract void ParseAttribute(T attr);
 
+        public override IEnumerable<TAttribute> GetDrawableAttributes<TAttribute>()
+        {
+            return _parsedAttributes.OfType<TAttribute>();
+        }
     }
 }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/PropertyGroupDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/PropertyGroupDrawable.cs
@@ -8,8 +8,8 @@ namespace Rhinox.GUIUtils.Editor
     public abstract class PropertyGroupDrawable<T> : GroupedDrawable
         where T : PropertyGroupAttribute
     {
-        protected readonly List<T> _parsedAttributes = new List<T>();
-
+        protected List<T> _groupAttributes = new List<T>();
+        
         protected PropertyGroupDrawable(GroupedDrawable parent, string groupID, float order) : base(parent, groupID, order)
         {
             
@@ -28,29 +28,28 @@ namespace Rhinox.GUIUtils.Editor
         {
             var groupAttribute = ValidateAttribute(attr);
 
+            _groupAttributes.Add(groupAttribute);
+            
             // No need to trigger ParseAttribute -> should have happened already, but it can't hurt
             ParseAttribute(groupAttribute);
             ParseAttribute(child, groupAttribute);
         }
 
         protected abstract void ParseAttribute(IOrderedDrawable child, T attr);
-
-        
-        protected override void ParseAttribute(PropertyGroupAttribute attr)
-        {
-            if (_parsedAttributes.Contains(attr))
-                return;
-
-            var groupAttribute = ValidateAttribute(attr);
-            _parsedAttributes.Add(groupAttribute);
-            ParseAttribute(groupAttribute);
-        }
-        
         protected abstract void ParseAttribute(T attr);
 
-        public override IEnumerable<TAttribute> GetDrawableAttributes<TAttribute>()
+        public override void AddAttribute(Attribute attr)
         {
-            return _parsedAttributes.OfType<TAttribute>();
+            if (_attributes.Contains(attr))
+                return;
+            
+            base.AddAttribute(attr);
+
+            if (attr is PropertyGroupAttribute groupAttribute)
+            {
+                var typedGroupAttribute = ValidateAttribute(groupAttribute);
+                ParseAttribute(typedGroupAttribute);
+            }
         }
     }
 }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/PropertyGroupDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/PropertyGroupDrawable.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Rhinox.Lightspeed;
 using Sirenix.OdinInspector;
 
 namespace Rhinox.GUIUtils.Editor
@@ -17,18 +18,17 @@ namespace Rhinox.GUIUtils.Editor
         
         protected T ValidateAttribute(PropertyGroupAttribute attr)
         {
-            if (attr is T typedAttr)
-                return typedAttr;
-            
-            // incorrect attribute
-            throw new ArgumentException(nameof(attr), $"{GetType().Name} cannot parse attribute of type {attr.GetType().Name}");
+            if (!(attr is T typedAttr)) // incorrect attribute
+                throw new ArgumentException(nameof(attr), $"{GetType().Name} cannot parse attribute of type {attr.GetType().Name}");
+
+            return typedAttr;
         }
 
         protected override void ParseAttribute(IOrderedDrawable child, PropertyGroupAttribute attr)
         {
             var groupAttribute = ValidateAttribute(attr);
 
-            _groupAttributes.Add(groupAttribute);
+            base.AddAttribute(attr);
             
             // No need to trigger ParseAttribute -> should have happened already, but it can't hurt
             ParseAttribute(groupAttribute);
@@ -48,6 +48,8 @@ namespace Rhinox.GUIUtils.Editor
             if (attr is PropertyGroupAttribute groupAttribute)
             {
                 var typedGroupAttribute = ValidateAttribute(groupAttribute);
+                _groupAttributes.AddUnique(typedGroupAttribute);
+
                 ParseAttribute(typedGroupAttribute);
             }
         }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/PropertyGroupDrawable.cs.meta
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/PropertyGroupDrawable.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 34524f51e858491a9ed9dac0bfd24bca
+timeCreated: 1680593084

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/TitleGroupDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/TitleGroupDrawable.cs
@@ -85,7 +85,6 @@ namespace Rhinox.GUIUtils.Editor
 
         protected override void ParseAttribute(IOrderedDrawable child, TitleGroupAttribute attr)
         {
-            // TODO
         }
 
         protected override void ParseAttribute(TitleGroupAttribute attr)

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/TitleGroupDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/TitleGroupDrawable.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace Rhinox.GUIUtils.Editor
 {
-    public class TitleGroupDrawable : VerticalGroupDrawable
+    public class TitleGroupDrawable : BaseVerticalGroupDrawable<TitleGroupAttribute>
     {
         public override float ElementHeight
         {
@@ -83,42 +83,31 @@ namespace Rhinox.GUIUtils.Editor
             base.Draw(rect, label);
         }
 
-        protected override void ParseAttribute(IOrderedDrawable child, PropertyGroupAttribute attr)
+        protected override void ParseAttribute(IOrderedDrawable child, TitleGroupAttribute attr)
         {
-            if (attr is TitleGroupAttribute groupAttribute)
-            {
-                // TODO
-            }
-            else // incorrect attribute
-                throw new ArgumentException(nameof(attr));
-            
+            // TODO
         }
 
-        protected override void ParseAttribute(PropertyGroupAttribute attr)
+        protected override void ParseAttribute(TitleGroupAttribute attr)
         {
-            if (attr is TitleGroupAttribute groupAttribute)
-            {
-                // TODO: current we just take the last entry, different entries having different data is invalid?
+            // TODO: current we just take the last entry, different entries having different data is invalid?
                 
-                if (!groupAttribute.GroupName.IsNullOrEmpty())
-                    Title = groupAttribute.GroupName;
+            if (!attr.GroupName.IsNullOrEmpty())
+                Title = attr.GroupName;
                 
-                if (groupAttribute.Order != 0)
-                    SetOrder(groupAttribute.Order);
+            if (attr.Order != 0)
+                SetOrder(attr.Order);
                 
-                if (!groupAttribute.HorizontalLine) // default is true so only set if you specify it
-                    HorizontalLine = false;
+            if (!attr.HorizontalLine) // default is true so only set if you specify it
+                HorizontalLine = false;
                 
-                if (groupAttribute.Alignment != TitleAlignments.Left)
-                    Alignment = groupAttribute.Alignment;
-                if (!groupAttribute.BoldTitle) // default is true so only set if you specify it
-                    Bold = false;
+            if (attr.Alignment != TitleAlignments.Left)
+                Alignment = attr.Alignment;
+            if (!attr.BoldTitle) // default is true so only set if you specify it
+                Bold = false;
                 
-                TitleStyle = UpdateStyle();
-                _parent?.EnsureSizeFits(_size);
-            }
-            else // incorrect attribute
-                throw new ArgumentException(nameof(attr));
+            TitleStyle = UpdateStyle();
+            _parent?.EnsureSizeFits(_size);
         }
 
         private GUIStyle UpdateStyle()

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/VerticalGroupDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/VerticalGroupDrawable.cs
@@ -1,32 +1,10 @@
 using System;
 using Sirenix.OdinInspector;
-using UnityEditor;
-using UnityEngine;
 
 namespace Rhinox.GUIUtils.Editor
 {
-    public class VerticalGroupDrawable : GroupedDrawable
+    public class VerticalGroupDrawable : BaseVerticalGroupDrawable<VerticalGroupAttribute>
     {
-        public override float ElementHeight
-        {
-            get
-            {
-                if (Children == null)
-                    return EditorGUIUtility.singleLineHeight;
-                
-                float height = 0.0f;
-                foreach (var child in Children)
-                {
-                    if (!child.IsVisible)
-                        continue;
-                    if (height > 0)
-                        height += CustomGUIUtility.Padding;
-                    height += child.ElementHeight;
-                }
-                return height;
-            }
-        }
-
         public VerticalGroupDrawable()
             : this(null, null, 0)
         {
@@ -38,68 +16,18 @@ namespace Rhinox.GUIUtils.Editor
         {
         }
 
-        public override void Draw(GUIContent label)
+        protected override void ParseAttribute(IOrderedDrawable child, VerticalGroupAttribute attr)
         {
-            if (_drawableMemberChildren == null)
-                return;
+            // TODO
+        }
 
-            var rect = EditorGUILayout.BeginVertical(CustomGUIStyles.Clean, GetLayoutOptions(_size));
+        protected override void ParseAttribute(VerticalGroupAttribute attr)
+        {
+            SetOrder(attr.Order);
             
-            foreach (var childDrawable in _drawableMemberChildren)
-            {
-                if (childDrawable == null || !childDrawable.IsVisible)
-                    continue;
-                
-                childDrawable.Draw(childDrawable.Label);
+            // TODO
 
-                GUILayout.Space(CustomGUIUtility.Padding); // padding
-            }
-            
-            EditorGUILayout.EndVertical();
-        }
-
-        public override void Draw(Rect rect, GUIContent label)
-        {
-            if (_drawableMemberChildren == null)
-                return;
-
-            Rect childRect = rect;
-            for (int i = 0; i < _drawableMemberChildren.Count; ++i)
-            {
-                var childDrawable = _drawableMemberChildren[i];
-                if (childDrawable == null || !childDrawable.IsVisible)
-                    continue;
-                
-                childRect.width = rect.width;
-                childRect.height = childDrawable.ElementHeight;
-                childDrawable.Draw(childRect, childDrawable.Label);
-                
-                childRect.y += childRect.height + CustomGUIUtility.Padding;
-            }
-        }
-
-        protected override void ParseAttribute(IOrderedDrawable child, PropertyGroupAttribute attr)
-        {
-            if (attr is VerticalGroupAttribute groupAttribute)
-            {
-                // TODO
-
-            }
-            else // incorrect attribute
-                throw new ArgumentException(nameof(attr));            
-        }
-
-        protected override void ParseAttribute(PropertyGroupAttribute attr)
-        {
-            if (attr is VerticalGroupAttribute groupAttribute)
-            {
-                SetOrder(groupAttribute.Order);
-                // TODO
-                
-                _parent?.EnsureSizeFits(_size);
-            }
-            else // incorrect attribute
-                throw new ArgumentException(nameof(attr));   
+            _parent?.EnsureSizeFits(_size);
         }
     }
 }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
@@ -18,11 +18,14 @@ namespace Rhinox.GUIUtils.Editor
         
         //==============================================================================================================
         // Public API
-        public static List<IOrderedDrawable> CreateDrawableMembersFor(object instance, Type t)
+        public static List<IOrderedDrawable> CreateDrawableMembersFor(GenericMemberEntry entry)
+            => CreateDrawableMembersFor(entry.Instance, entry.GetReturnType(), entry);
+        
+        public static List<IOrderedDrawable> CreateDrawableMembersFor(object instance, Type t, GenericMemberEntry parent = null)
         {
             if (t == typeof(UnityEngine.Object))
                 return new List<IOrderedDrawable>() {new DrawableUnityObject((UnityEngine.Object) instance)};
-            return CreateDrawableMembersFor(instance, t, 0);
+            return CreateDrawableMembersFor(instance, t, 0, parent);
         }
         
         public static List<IOrderedDrawable> CreateDrawableMembersFor(SerializedObject obj, Type type)

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
@@ -24,14 +24,9 @@ namespace Rhinox.GUIUtils.Editor
             return CreateDrawableFor(entry.GetValue(), entry.GetReturnType(), entry);
         }
 
-        public static IOrderedDrawable CreateDrawableFor(object instance, Type type, GenericMemberEntry parent = null)
+        public static IOrderedDrawable CreateDrawableFor(object instance, Type type)
         {
-            if (type == null)
-                throw new ArgumentNullException(nameof(type));
-            
-            if (type.InheritsFrom<UnityEngine.Object>())
-                return new DrawableUnityObject((UnityEngine.Object) instance);
-            return CreateCompositeDrawable(instance, type, 0, parent);
+            return CreateDrawableFor(instance, type, null);
         }
         
         public static IOrderedDrawable CreateDrawableFor(SerializedObject obj, Type type)
@@ -78,6 +73,16 @@ namespace Rhinox.GUIUtils.Editor
 
         //==============================================================================================================
         // Helper methods
+
+        private static IOrderedDrawable CreateDrawableFor(object instance, Type type, GenericMemberEntry parent)
+        {
+            if (type == null)
+                throw new ArgumentNullException(nameof(type));
+            
+            if (type.InheritsFrom<UnityEngine.Object>())
+                return new DrawableUnityObject((UnityEngine.Object) instance);
+            return CreateCompositeDrawable(instance, type, 0, parent);
+        }
         
         private static IOrderedDrawable DrawableMembersForSerializedObject(object instanceVal, Type type, IEnumerable<SerializedObjectExtensions.FieldData> visibleFields, int depth)
         {

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
@@ -19,8 +19,12 @@ namespace Rhinox.GUIUtils.Editor
         //==============================================================================================================
         // Public API
         public static List<IOrderedDrawable> CreateDrawableMembersFor(GenericMemberEntry entry)
-            => CreateDrawableMembersFor(entry.GetValue(), entry.GetReturnType(), entry);
-        
+        {
+            if (TryCreate(entry, out var drawableMember))
+                return new List<IOrderedDrawable>() {drawableMember};
+            return CreateDrawableMembersFor(entry.GetValue(), entry.GetReturnType(), entry);
+        }
+
         public static List<IOrderedDrawable> CreateDrawableMembersFor(object instance, Type type, GenericMemberEntry parent = null)
         {
             if (type == null)

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
@@ -19,20 +19,26 @@ namespace Rhinox.GUIUtils.Editor
         //==============================================================================================================
         // Public API
         public static List<IOrderedDrawable> CreateDrawableMembersFor(GenericMemberEntry entry)
-            => CreateDrawableMembersFor(entry.Instance, entry.GetReturnType(), entry);
+            => CreateDrawableMembersFor(entry.GetValue(), entry.GetReturnType(), entry);
         
-        public static List<IOrderedDrawable> CreateDrawableMembersFor(object instance, Type t, GenericMemberEntry parent = null)
+        public static List<IOrderedDrawable> CreateDrawableMembersFor(object instance, Type type, GenericMemberEntry parent = null)
         {
-            if (t == typeof(UnityEngine.Object))
+            if (type == null)
+                throw new ArgumentNullException(nameof(type));
+            
+            if (type.InheritsFrom<UnityEngine.Object>())
                 return new List<IOrderedDrawable>() {new DrawableUnityObject((UnityEngine.Object) instance)};
-            return CreateDrawableMembersFor(instance, t, 0, parent);
+            return CreateDrawableMembersFor(instance, type, 0, parent);
         }
         
         public static List<IOrderedDrawable> CreateDrawableMembersFor(SerializedObject obj, Type type)
         {
             object instanceVal = obj.targetObject;
             
-            if (type == typeof(UnityEngine.Object))
+            if (type == null)
+                throw new ArgumentNullException(nameof(type));
+            
+            if (type.InheritsFrom<UnityEngine.Object>())
                 return new List<IOrderedDrawable>() {new DrawableUnityObject((UnityEngine.Object)instanceVal)};
             
             var visibleFields = obj.EnumerateEditorVisibleFields();

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
@@ -41,25 +41,29 @@ namespace Rhinox.GUIUtils.Editor
             return DrawableMembersForSerializedObject(instanceVal, type, visibleFields, 0);
         }
         
-        public static IOrderedDrawable CreateDrawableFor(SerializedProperty property, Type type)
+        public static IOrderedDrawable CreateDrawableFor(SerializedProperty property)
         {
             if (property == null)
                 return null;
             
-            object instanceVal = property.GetValue();
-
             if (CanUnityHandleDrawingProperty(property))
             {
                 IOrderedDrawable drawable = new DrawableUnityProperty(property, property.FindFieldInfo());
                 drawable = DrawableWrapperFactory.TryWrapDrawable(drawable, property.GetAttributes().Append(new HideLabelAttribute()));
                 return drawable;
             }
-
+            
+            var hostInfo = property.GetHostInfo();
+            object instanceVal = property.GetValue();
+            
             if (instanceVal == null)
                 return new NullReferenceDrawable(property);
-
+            
+            if (AttributeParser.ParseDrawAsUnity(hostInfo.FieldInfo))
+                return new DrawableUnityObject((UnityEngine.Object)instanceVal, property.FindFieldInfo());
+            
             var visibleFields = property.EnumerateEditorVisibleFields();
-            return DrawableMembersForSerializedObject(instanceVal, type, visibleFields, 0);
+            return DrawableMembersForSerializedObject(instanceVal, hostInfo.GetReturnType(), visibleFields, 0);
         }
 
         public static void SortDrawables(this List<IOrderedDrawable> drawables)

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
@@ -34,7 +34,7 @@ namespace Rhinox.GUIUtils.Editor
             if (type == null)
                 throw new ArgumentNullException(nameof(type));
             
-            if (type.InheritsFrom<UnityEngine.Object>())
+            if (type == typeof(UnityEngine.Object))
                 return new DrawableUnityObject((UnityEngine.Object)instanceVal);
             
             var visibleFields = obj.EnumerateEditorVisibleFields();
@@ -48,7 +48,7 @@ namespace Rhinox.GUIUtils.Editor
             
             object instanceVal = property.GetValue();
             
-            if (type.InheritsFrom<UnityEngine.Object>())
+            if (type == typeof(UnityEngine.Object))
                 return new DrawableUnityProperty(property, property.FindFieldInfo());
 
             if (instanceVal == null)

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
@@ -20,8 +20,8 @@ namespace Rhinox.GUIUtils.Editor
         // Public API
         public static List<IOrderedDrawable> CreateDrawableMembersFor(object instance, Type t)
         {
-            if (t == typeof(GameObject))
-                return new List<IOrderedDrawable>() {new DrawableUnityObject((GameObject)instance)};
+            if (t == typeof(UnityEngine.Object))
+                return new List<IOrderedDrawable>() {new DrawableUnityObject((UnityEngine.Object) instance)};
             return CreateDrawableMembersFor(instance, t, 0);
         }
         
@@ -29,8 +29,8 @@ namespace Rhinox.GUIUtils.Editor
         {
             object instanceVal = obj.targetObject;
             
-            if (type == typeof(GameObject))
-                return new List<IOrderedDrawable>() {new DrawableUnityObject((GameObject)instanceVal)};
+            if (type == typeof(UnityEngine.Object))
+                return new List<IOrderedDrawable>() {new DrawableUnityObject((UnityEngine.Object)instanceVal)};
             
             var visibleFields = obj.EnumerateEditorVisibleFields();
             return DrawableMembersFor(instanceVal, type, visibleFields, 0);
@@ -62,8 +62,6 @@ namespace Rhinox.GUIUtils.Editor
             
             object instanceVal = property.GetValue();
             
-            if (type == typeof(GameObject))
-                return new List<IOrderedDrawable>() { new DrawableUnityObject((GameObject)instanceVal, property.FindFieldInfo()) };
             if (type.InheritsFrom<UnityEngine.Object>())
                 return new List<IOrderedDrawable>() { new DrawableUnityProperty(property, property.FindFieldInfo()) };
 
@@ -199,7 +197,11 @@ namespace Rhinox.GUIUtils.Editor
                 var attributes = mi.GetCustomAttributes();
                 var attr = attributes.OfType<ButtonAttribute>().First();
                 
-                IOrderedDrawable button = new DrawableButton(instance, mi, attr);
+                IOrderedDrawable button = new DrawableButton(instance, mi)
+                {
+                    Name = attr.Name,
+                    Height = attr.ButtonHeight
+                };
                 button = DrawableWrapperFactory.TryWrapDrawable(button, attributes);
                 buttons.AddUnique(button);
             }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
@@ -19,8 +19,6 @@ namespace Rhinox.GUIUtils.Editor
         // Public API
         public static IOrderedDrawable CreateDrawableFor(GenericMemberEntry entry)
         {
-            if (TryCreateDirect(entry, out var drawableMember))
-                return drawableMember;
             return CreateDrawableFor(entry.GetValue(), entry.GetReturnType(), entry);
         }
 
@@ -81,6 +79,10 @@ namespace Rhinox.GUIUtils.Editor
             
             if (type.InheritsFrom<UnityEngine.Object>())
                 return new DrawableUnityObject((UnityEngine.Object) instance);
+
+            if (parent != null)
+                return CreateDrawableForMember(parent, 0);
+            
             return CreateCompositeDrawable(instance, type, 0, parent);
         }
         

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
@@ -49,7 +49,7 @@ namespace Rhinox.GUIUtils.Editor
             if (forceDrawAsUnityObject)
                 _drawables = new[] {new DrawableUnityObject((UnityEngine.Object) entry.GetValue(), entry.Info)};
             else
-                _drawables = DrawableFactory.CreateDrawableMembersFor(entry);
+                _drawables = DrawableFactory.CreateDrawableFor(entry);
         }
         
         public DrawablePropertyView(SerializedObject serializedObject, bool forceDrawAsUnityObject = false)
@@ -85,7 +85,7 @@ namespace Rhinox.GUIUtils.Editor
 
             var type = obj.GetType();
 
-            var drawables = DrawableFactory.CreateDrawableMembersFor(obj, type);
+            var drawables = DrawableFactory.CreateDrawableFor(obj, type);
 
             if (drawables.Count == 0 && obj is UnityEngine.Object unityObj)
                 drawables.Add(new DrawableUnityObject(unityObj, null));
@@ -109,7 +109,7 @@ namespace Rhinox.GUIUtils.Editor
             if (AttributeParser.ParseDrawAsUnity(hostInfo.FieldInfo))
                 return new[] {new DrawableUnityObject((UnityEngine.Object)property.GetValue(), property.FindFieldInfo())};
 
-            var drawables = DrawableFactory.CreateDrawableMembersFor(property, type);
+            var drawables = DrawableFactory.CreateDrawableFor(property, type);
 
             if (drawables.IsNullOrEmpty()) return drawables;
             
@@ -125,7 +125,7 @@ namespace Rhinox.GUIUtils.Editor
 
             var type = obj.targetObject.GetType();
 
-            var drawables = DrawableFactory.CreateDrawableMembersFor(obj, type);
+            var drawables = DrawableFactory.CreateDrawableFor(obj, type);
 
             if (drawables.IsNullOrEmpty()) return drawables;
             

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
@@ -45,7 +45,7 @@ namespace Rhinox.GUIUtils.Editor
             _serializedObject = null;
 
             if (forceDrawAsUnityObject)
-                _rootDrawable = new DrawableUnityObject((UnityEngine.Object) entry.GetValue(), entry.Info);
+                _rootDrawable = new DrawableUnityObject(entry);
             else
                 _rootDrawable = DrawableFactory.CreateDrawableFor(entry);
         }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
@@ -31,7 +31,7 @@ namespace Rhinox.GUIUtils.Editor
             _instance = unityObjInstance;
             _serializedObject = null;
             if (forceDrawAsUnityObject)
-                _drawables = new[] {new DrawableUnityObject((GameObject)unityObjInstance)};
+                _drawables = new[] {new DrawableUnityObject((UnityEngine.Object) unityObjInstance)};
             else
                 _drawables = ParseNonUnityObject(unityObjInstance);
         }
@@ -68,7 +68,7 @@ namespace Rhinox.GUIUtils.Editor
             var drawables = DrawableFactory.CreateDrawableMembersFor(obj, type);
 
             if (drawables.Count == 0 && obj is UnityEngine.Object unityObj)
-                drawables.Add(new DrawableUnityObject((GameObject)unityObj, null));
+                drawables.Add(new DrawableUnityObject(unityObj, null));
 
             if (drawables.IsNullOrEmpty())
                 return drawables;

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
@@ -47,7 +47,7 @@ namespace Rhinox.GUIUtils.Editor
             _serializedObject = null;
             
             if (forceDrawAsUnityObject)
-                _drawables = new[] {new DrawableUnityObject((UnityEngine.Object) entry.Instance, entry.Info)};
+                _drawables = new[] {new DrawableUnityObject((UnityEngine.Object) entry.GetValue(), entry.Info)};
             else
                 _drawables = DrawableFactory.CreateDrawableMembersFor(entry);
         }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
@@ -11,6 +11,7 @@ namespace Rhinox.GUIUtils.Editor
     public class DrawablePropertyView
     {
         private readonly object _instance;
+        private readonly GenericMemberEntry _entry;
         private readonly SerializedObject _serializedObject;
         private readonly ICollection<IOrderedDrawable> _drawables;
 
@@ -25,15 +26,30 @@ namespace Rhinox.GUIUtils.Editor
             }
         }
 
-        public DrawablePropertyView(object unityObjInstance, bool forceDrawAsUnityObject = false)
+        public DrawablePropertyView(object instance, bool forceDrawAsUnityObject = false)
         {
-            if (unityObjInstance == null) throw new ArgumentNullException(nameof(unityObjInstance));
-            _instance = unityObjInstance;
+            if (instance == null) throw new ArgumentNullException(nameof(instance));
+            _instance = instance;
+            _entry = null;
             _serializedObject = null;
+            
             if (forceDrawAsUnityObject)
-                _drawables = new[] {new DrawableUnityObject((UnityEngine.Object) unityObjInstance)};
+                _drawables = new[] {new DrawableUnityObject((UnityEngine.Object) instance)};
             else
-                _drawables = ParseNonUnityObject(unityObjInstance);
+                _drawables = ParseNonUnityObject(instance);
+        }
+        
+        public DrawablePropertyView(GenericMemberEntry entry, bool forceDrawAsUnityObject = false)
+        {
+            if (entry == null) throw new ArgumentNullException(nameof(entry));
+            _entry = entry;
+            _instance = _entry.Instance;
+            _serializedObject = null;
+            
+            if (forceDrawAsUnityObject)
+                _drawables = new[] {new DrawableUnityObject((UnityEngine.Object) entry.Instance, entry.Info)};
+            else
+                _drawables = DrawableFactory.CreateDrawableMembersFor(entry);
         }
         
         public DrawablePropertyView(SerializedObject serializedObject, bool forceDrawAsUnityObject = false)
@@ -41,6 +57,8 @@ namespace Rhinox.GUIUtils.Editor
             if (serializedObject == null) throw new ArgumentNullException(nameof(serializedObject));
             _instance = serializedObject;
             _serializedObject = serializedObject;
+            _entry = null;
+            
             if (forceDrawAsUnityObject)
                 _drawables = new[] {new DrawableUnityObject(serializedObject.targetObject)};
             else
@@ -52,6 +70,8 @@ namespace Rhinox.GUIUtils.Editor
             if (property == null) throw new ArgumentNullException(nameof(property));
             _instance = property;
             _serializedObject = property.serializedObject;
+            _entry = null;
+            
             if (forceDrawAsUnityObject)
                 _drawables = new[] {new DrawableUnityObject((UnityEngine.Object) property.GetValue())};
             else

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
@@ -24,56 +24,44 @@ namespace Rhinox.GUIUtils.Editor
 
         public float Height => _rootDrawable != null ? _rootDrawable.ElementHeight : 0.0f;
 
-        public DrawablePropertyView(object instance, bool forceDrawAsUnityObject = false)
+        public DrawablePropertyView(object instance)
         {
             if (instance == null) throw new ArgumentNullException(nameof(instance));
             _instance = instance;
             _entry = null;
             _serializedObject = null;
             
-            if (forceDrawAsUnityObject)
-                _rootDrawable = new DrawableUnityObject((UnityEngine.Object) _instance);
-            else
-                _rootDrawable = ParseNonUnityObject(instance);
+            _rootDrawable = ParseNonUnityObject(instance);
         }
         
-        public DrawablePropertyView(GenericMemberEntry entry, bool forceDrawAsUnityObject = false)
+        public DrawablePropertyView(GenericMemberEntry entry)
         {
             if (entry == null) throw new ArgumentNullException(nameof(entry));
             _entry = entry;
             _instance = _entry.Instance;
             _serializedObject = null;
 
-            if (forceDrawAsUnityObject)
-                _rootDrawable = new UnityObjectDrawableField(entry);
-            else
-                _rootDrawable = DrawableFactory.CreateDrawableFor(entry);
+            _rootDrawable = DrawableFactory.CreateDrawableFor(entry);
         }
         
-        public DrawablePropertyView(SerializedObject serializedObject, bool forceDrawAsUnityObject = false)
+        public DrawablePropertyView(SerializedObject serializedObject)
         {
             if (serializedObject == null) throw new ArgumentNullException(nameof(serializedObject));
             _instance = serializedObject;
             _serializedObject = serializedObject;
             _entry = null;
             
-            if (forceDrawAsUnityObject)
-                _rootDrawable = new DrawableUnityObject(serializedObject.targetObject);
-            else
-                _rootDrawable = ParseSerializedObject(serializedObject);
+            _rootDrawable = ParseSerializedObject(serializedObject);
         }
         
-        public DrawablePropertyView(SerializedProperty property, bool forceDrawAsUnityObject = false)
+        public DrawablePropertyView(SerializedProperty property)
         {
             if (property == null) throw new ArgumentNullException(nameof(property));
             _instance = property;
             _serializedObject = property.serializedObject;
             _entry = null;
             
-            if (forceDrawAsUnityObject)
-                _rootDrawable = new DrawableUnityObject((UnityEngine.Object) property.GetValue());
-            else
-                _rootDrawable = ParseSerializedProperty(property);
+            _rootDrawable = ParseSerializedProperty(property);
         }
         
         protected static IOrderedDrawable ParseNonUnityObject(object obj)

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
@@ -45,7 +45,7 @@ namespace Rhinox.GUIUtils.Editor
             _serializedObject = null;
 
             if (forceDrawAsUnityObject)
-                _rootDrawable = new DrawableUnityObject(entry);
+                _rootDrawable = new UnityObjectDrawableField(entry);
             else
                 _rootDrawable = DrawableFactory.CreateDrawableFor(entry);
         }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
@@ -25,7 +25,7 @@ namespace Rhinox.GUIUtils.Editor
             _serializedObject = null;
             
             if (forceDrawAsUnityObject)
-                _rootDrawable = new DrawableUnityObject((UnityEngine.Object) instance);
+                _rootDrawable = new DrawableUnityObject((UnityEngine.Object) _instance);
             else
                 _rootDrawable = ParseNonUnityObject(instance);
         }
@@ -131,7 +131,7 @@ namespace Rhinox.GUIUtils.Editor
             
             
             // TODO: should we force height?
-            //rect.height = Height;
+            rect.height = Height;
             _rootDrawable.Draw(rect, _rootDrawable.Label);
             
             OnPostDraw();

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
@@ -15,6 +15,13 @@ namespace Rhinox.GUIUtils.Editor
         private readonly SerializedObject _serializedObject;
         private readonly IOrderedDrawable _rootDrawable;
 
+        public bool ShouldRepaint { get; private set; }
+
+        internal void MarkAsRepainted()
+        {
+            ShouldRepaint = false;
+        }
+
         public float Height => _rootDrawable != null ? _rootDrawable.ElementHeight : 0.0f;
 
         public DrawablePropertyView(object instance, bool forceDrawAsUnityObject = false)
@@ -148,6 +155,9 @@ namespace Rhinox.GUIUtils.Editor
 
         private void OnPostDraw()
         {
+            if (_rootDrawable != null && _rootDrawable.ShouldRepaint)
+                ShouldRepaint = true;
+            
             if (_serializedObject != null)
                 _serializedObject.ApplyModifiedProperties();
         }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
@@ -42,7 +42,7 @@ namespace Rhinox.GUIUtils.Editor
             _instance = serializedObject;
             _serializedObject = serializedObject;
             if (forceDrawAsUnityObject)
-                _drawables = new[] {new DrawableUnityObject((GameObject)serializedObject.targetObject)};
+                _drawables = new[] {new DrawableUnityObject(serializedObject.targetObject)};
             else
                 _drawables = ParseSerializedObject(serializedObject);
         }
@@ -53,7 +53,7 @@ namespace Rhinox.GUIUtils.Editor
             _instance = property;
             _serializedObject = property.serializedObject;
             if (forceDrawAsUnityObject)
-                _drawables = new[] {new DrawableUnityObject((GameObject)property.GetValue())};
+                _drawables = new[] {new DrawableUnityObject((UnityEngine.Object) property.GetValue())};
             else
                 _drawables = ParseSerializedProperty(property);
         }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
@@ -17,11 +17,6 @@ namespace Rhinox.GUIUtils.Editor
 
         public bool ShouldRepaint { get; private set; }
 
-        internal void MarkAsRepainted()
-        {
-            ShouldRepaint = false;
-        }
-
         public float Height => _rootDrawable != null ? _rootDrawable.ElementHeight : 0.0f;
 
         public DrawablePropertyView(object instance)
@@ -31,7 +26,7 @@ namespace Rhinox.GUIUtils.Editor
             _entry = null;
             _serializedObject = null;
             
-            _rootDrawable = ParseNonUnityObject(instance);
+            _rootDrawable = DrawableFactory.CreateDrawableFor(_instance, _instance.GetType());
         }
         
         public DrawablePropertyView(GenericMemberEntry entry)
@@ -51,7 +46,7 @@ namespace Rhinox.GUIUtils.Editor
             _serializedObject = serializedObject;
             _entry = null;
             
-            _rootDrawable = ParseSerializedObject(serializedObject);
+            _rootDrawable = DrawableFactory.CreateDrawableFor(_serializedObject, _serializedObject.targetObject.GetType());
         }
         
         public DrawablePropertyView(SerializedProperty property)
@@ -61,48 +56,7 @@ namespace Rhinox.GUIUtils.Editor
             _serializedObject = property.serializedObject;
             _entry = null;
             
-            _rootDrawable = ParseSerializedProperty(property);
-        }
-        
-        protected static IOrderedDrawable ParseNonUnityObject(object obj)
-        {
-            if (obj == null)
-                return null;
-
-            var type = obj.GetType();
-
-            var drawable = DrawableFactory.CreateDrawableFor(obj, type);
-
-            if (drawable == null && obj is UnityEngine.Object unityObj)
-                drawable = new DrawableUnityObject(unityObj, null);
-
-            return drawable;
-        }
-
-        protected static IOrderedDrawable ParseSerializedProperty(SerializedProperty property)
-        {
-            if (property == null)
-                return null;
-
-            var hostInfo = property.GetHostInfo();
-            var type = hostInfo.GetReturnType();
-
-            if (AttributeParser.ParseDrawAsUnity(hostInfo.FieldInfo))
-                return new DrawableUnityObject((UnityEngine.Object)property.GetValue(), property.FindFieldInfo());
-
-            var drawable = DrawableFactory.CreateDrawableFor(property, type);
-            return drawable;
-        }
-
-        protected static IOrderedDrawable ParseSerializedObject(SerializedObject obj)
-        {
-            if (obj == null || obj.targetObject == null)
-                return null;
-
-            var type = obj.targetObject.GetType();
-
-            var drawable = DrawableFactory.CreateDrawableFor(obj, type);
-            return drawable;
+            _rootDrawable = DrawableFactory.CreateDrawableFor(property);
         }
         
         public void DrawLayout()
@@ -149,5 +103,11 @@ namespace Rhinox.GUIUtils.Editor
             if (_serializedObject != null)
                 _serializedObject.ApplyModifiedProperties();
         }
+        
+        internal void MarkAsRepainted()
+        {
+            ShouldRepaint = false;
+        }
+
     }
 }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableButton.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableButton.cs
@@ -28,10 +28,10 @@ namespace Rhinox.GUIUtils.Editor
             _methodInfo = method;
         }
         
-        protected override void DrawInner(GUIContent label)
+        protected override void DrawInner(GUIContent label, params GUILayoutOption[] options)
         {
             var height = Height == 0 ? (int)EditorGUIUtility.singleLineHeight : Height;
-            if (GUILayout.Button((Name ?? _methodInfo.Name).SplitCamelCase(), GUILayout.Height(height)))
+            if (GUILayout.Button((Name ?? _methodInfo.Name).SplitCamelCase(), options.Append(GUILayout.Height(height))))
             {
                 if (!TryCreateDialog(_methodInfo, Host))
                     _methodInfo.Invoke(Host, null);

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableButton.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableButton.cs
@@ -15,24 +15,23 @@ namespace Rhinox.GUIUtils.Editor
     {
         public override string LabelString => null; // TODO: Button has no label?
         
-        public string Name { get; }
+        public string Name { get; set; }
+        
+        public float Height { get; set; }
 
         private readonly MethodInfo _methodInfo;
-        private readonly ButtonAttribute _buttonAttr;
 
-        public DrawableButton(object instanceVal, MethodInfo method, ButtonAttribute buttonAttr)
+        public DrawableButton(object instanceVal, MethodInfo method)
             : base(instanceVal, method)
         {
             Host = instanceVal;
             _methodInfo = method;
-            _buttonAttr = buttonAttr;
         }
         
         protected override void DrawInner(GUIContent label)
         {
-            var buttonHeight = _buttonAttr.ButtonHeight;
-            buttonHeight = buttonHeight == 0 ? (int)EditorGUIUtility.singleLineHeight : buttonHeight;
-            if (GUILayout.Button((_buttonAttr.Name ?? _methodInfo.Name).SplitCamelCase(), GUILayout.Height(buttonHeight)))
+            var height = Height == 0 ? (int)EditorGUIUtility.singleLineHeight : Height;
+            if (GUILayout.Button((Name ?? _methodInfo.Name).SplitCamelCase(), GUILayout.Height(height)))
             {
                 if (!TryCreateDialog(_methodInfo, Host))
                     _methodInfo.Invoke(Host, null);
@@ -41,10 +40,9 @@ namespace Rhinox.GUIUtils.Editor
 
         protected override void DrawInner(Rect rect, GUIContent label)
         {
-            var buttonHeight = _buttonAttr.ButtonHeight;
-            buttonHeight = buttonHeight == 0 ? (int)EditorGUIUtility.singleLineHeight : buttonHeight;
+            var buttonHeight = Height == 0 ? (int)EditorGUIUtility.singleLineHeight : Height;
             rect.height = buttonHeight;
-            if (GUI.Button(rect, (_buttonAttr.Name ?? _methodInfo.Name).SplitCamelCase()))
+            if (GUI.Button(rect, (Name ?? _methodInfo.Name).SplitCamelCase()))
             {
                 if (!TryCreateDialog(_methodInfo, Host))
                     _methodInfo.Invoke(Host, null);

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableHelpBox.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableHelpBox.cs
@@ -13,7 +13,7 @@ namespace Rhinox.GUIUtils.Editor
             MsgType = type;
         }
 
-        protected override void DrawInner(GUIContent label)
+        protected override void DrawInner(GUIContent label, params GUILayoutOption[] options)
         {
             EditorGUILayout.HelpBox(Entity, MsgType);
         }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableList.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableList.cs
@@ -125,7 +125,7 @@ namespace Rhinox.GUIUtils.Editor
             return _listRO.elementHeight;
         }
 
-        protected override void DrawInner(GUIContent label)
+        protected override void DrawInner(GUIContent label, params GUILayoutOption[] options)
         {
             if (_listRO != null && _listDrawerAttr != null)
             {

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableList.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableList.cs
@@ -39,7 +39,7 @@ namespace Rhinox.GUIUtils.Editor
 
         public void Draw(Rect r)
         {
-            r.y += 2.0f;
+            r.y += CustomGUIUtility.Padding;
             if (_propertyView != null)
                 _propertyView.Draw(r);
         }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableList.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableList.cs
@@ -95,7 +95,7 @@ namespace Rhinox.GUIUtils.Editor
             _listDrawerAttr = entry.GetAttribute<ListDrawerSettingsAttribute>() ?? new ListDrawerSettingsAttribute();
             _drawElementsAsUnity = entry.GetAttribute<DrawAsUnityObjectAttribute>() != null;
 
-            _listRO = new PageableReorderableList(_entry.Instance, _entry.Info,
+            _listRO = new PageableReorderableList(_entry,
                 _listDrawerAttr.DraggableItems, true,
                 !_listDrawerAttr.IsReadOnly && !_listDrawerAttr.HideAddButton,
                 !_listDrawerAttr.IsReadOnly && !_listDrawerAttr.HideRemoveButton)

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableList.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableList.cs
@@ -21,20 +21,20 @@ namespace Rhinox.GUIUtils.Editor
         private readonly GenericElementMemberEntry _entry;
         private readonly DrawablePropertyView _propertyView;
 
-        public ListElementDrawable(SerializedProperty property, float defaultElementHeight = 18.0f, bool drawElementsAsUnity = false)
+        public ListElementDrawable(SerializedProperty property, float defaultElementHeight = 18.0f)
         {
             if (property == null) throw new ArgumentNullException(nameof(property));
             _defaultElementHeight = defaultElementHeight;
             _property = property;
-            _propertyView = new DrawablePropertyView(property, drawElementsAsUnity);
+            _propertyView = new DrawablePropertyView(property);
         }
 
-        public ListElementDrawable(GenericElementMemberEntry entry, float defaultElementHeight = 18.0f, bool drawElementsAsUnity = false)
+        public ListElementDrawable(GenericElementMemberEntry entry, float defaultElementHeight = 18.0f)
         {
             _entry = entry;
             _defaultElementHeight = defaultElementHeight;
             _property = null;
-            _propertyView = new DrawablePropertyView(_entry, drawElementsAsUnity);
+            _propertyView = new DrawablePropertyView(_entry);
         }
 
         public void Draw(Rect r)
@@ -53,7 +53,6 @@ namespace Rhinox.GUIUtils.Editor
 
         private readonly SerializedProperty _listProperty;
         private readonly GenericMemberEntry _entry;
-        private readonly bool _drawElementsAsUnity;
 
         public override float ElementHeight
         {
@@ -75,7 +74,6 @@ namespace Rhinox.GUIUtils.Editor
             _entry = null;
 
             _listDrawerAttr = listProperty.GetAttributeOrCreate<ListDrawerSettingsAttribute>();
-            _drawElementsAsUnity = listProperty.GetAttribute<DrawAsUnityObjectAttribute>() != null;
 
             _listRO = new PageableReorderableList(listProperty.serializedObject, listProperty,
                 _listDrawerAttr.DraggableItems, true,
@@ -93,7 +91,6 @@ namespace Rhinox.GUIUtils.Editor
             _listProperty = null;
             _entry = entry;
             _listDrawerAttr = entry.GetAttribute<ListDrawerSettingsAttribute>() ?? new ListDrawerSettingsAttribute();
-            _drawElementsAsUnity = entry.GetAttribute<DrawAsUnityObjectAttribute>() != null;
 
             _listRO = new PageableReorderableList(_entry,
                 _listDrawerAttr.DraggableItems, true,
@@ -174,20 +171,20 @@ namespace Rhinox.GUIUtils.Editor
                 return;
             
             if (_listElements[index] == null)
-                _listElements[index] = CreateElementFor(index, _drawElementsAsUnity);
+                _listElements[index] = CreateElementFor(index);
             _listElements[index].Draw(rect);
         }
 
-        private ListElementDrawable CreateElementFor(int index, bool drawElementsAsUnity = false)
+        private ListElementDrawable CreateElementFor(int index)
         {
             if (_listProperty != null)
             {
                 var element = _listProperty.GetArrayElementAtIndex(index);
-                return new ListElementDrawable(element, _listRO.elementHeight, drawElementsAsUnity);
+                return new ListElementDrawable(element, _listRO.elementHeight);
             }
 
             var elementEntry = new GenericElementMemberEntry(_entry, index);
-            return new ListElementDrawable(elementEntry, _listRO.elementHeight, drawElementsAsUnity);
+            return new ListElementDrawable(elementEntry, _listRO.elementHeight);
         }
 
         private void OnBeginDraw()

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableList.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableList.cs
@@ -159,6 +159,7 @@ namespace Rhinox.GUIUtils.Editor
         private void OnChangedListCallback(BetterReorderableList list)
         {
             _listElements = new ListElementDrawable[list.count];
+            ShouldRepaint = true;
         }
 
         private void DrawElement(Rect rect, int index, bool isActive, bool isFocused)

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableUnityObject.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableUnityObject.cs
@@ -21,10 +21,10 @@ namespace Rhinox.GUIUtils.Editor
             _genericMemberEntry = entry;
         }
 
-        protected override void DrawInner(GUIContent label)
+        protected override void DrawInner(GUIContent label, params GUILayoutOption[] options)
         {
             // TODO: should we ever set this value?
-            EditorGUILayout.ObjectField(label, Entity, GetAppropriateType(), true);
+            EditorGUILayout.ObjectField(label, Entity, GetAppropriateType(), true, options);
         }
 
         protected override void DrawInner(Rect rect, GUIContent label)

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableUnityObject.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableUnityObject.cs
@@ -3,14 +3,22 @@ using System.Reflection;
 using Rhinox.Lightspeed.Reflection;
 using UnityEditor;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace Rhinox.GUIUtils.Editor
 {
     public class DrawableUnityObject : BaseEntityDrawable<UnityEngine.Object>
     {
+        private readonly GenericMemberEntry _genericMemberEntry;
+
         public DrawableUnityObject(UnityEngine.Object instance, MemberInfo hostMemberInfo = null) 
             : base(instance, hostMemberInfo)
         {
+        }
+
+        public DrawableUnityObject(GenericMemberEntry entry) : base((UnityEngine.Object) entry.GetValue(), entry.Info)
+        {
+            _genericMemberEntry = entry;
         }
 
         protected override void DrawInner(GUIContent label)
@@ -27,6 +35,8 @@ namespace Rhinox.GUIUtils.Editor
         {
             if (Entity != null)
                 return Entity.GetType();
+            if (_genericMemberEntry != null)
+                return _genericMemberEntry.GetReturnType();
             if (this._memberInfo != null)
                 return _memberInfo.GetReturnType();
             return typeof(UnityEngine.Object);

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableUnityObject.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableUnityObject.cs
@@ -23,11 +23,13 @@ namespace Rhinox.GUIUtils.Editor
 
         protected override void DrawInner(GUIContent label)
         {
+            // TODO: should we ever set this value?
             EditorGUILayout.ObjectField(label, Entity, GetAppropriateType(), true);
         }
 
         protected override void DrawInner(Rect rect, GUIContent label)
         {
+            // TODO: should we ever set this value?
             EditorGUI.ObjectField(rect, label, Entity, GetAppropriateType(), true);
         }
 

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableUnityProperty.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/DrawableUnityProperty.cs
@@ -14,9 +14,9 @@ namespace Rhinox.GUIUtils.Editor
             Host = prop;
         }
         
-        protected override void DrawInner(GUIContent label)
+        protected override void DrawInner(GUIContent label, params GUILayoutOption[] options) 
         {
-            EditorGUILayout.PropertyField(Entity, label);
+            EditorGUILayout.PropertyField(Entity, label, options);
         }
 
         protected override void DrawInner(Rect rect, GUIContent label)

--- a/Assets/GUIUtils/Editor/GUI/Drawables/IOrderedDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/IOrderedDrawable.cs
@@ -12,7 +12,8 @@ namespace Rhinox.GUIUtils.Editor
         object Host { get; }
         bool IsVisible { get; }
         GUIContent Label { get; }
-        
+        bool ShouldRepaint { get; }
+
         IEnumerable<TAttribute> GetDrawableAttributes<TAttribute>() where TAttribute : Attribute;
         void Draw(GUIContent label, params GUILayoutOption[] options);
         void Draw(Rect rect, GUIContent label);

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Members/BaseMemberDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Members/BaseMemberDrawable.cs
@@ -26,9 +26,6 @@ namespace Rhinox.GUIUtils.Editor
             Host = entry;
         }
 
-        protected override void DrawInner(GUIContent label)
-            => DrawInner(label, Array.Empty<GUILayoutOption>());
-
         protected override void DrawInner(GUIContent label, params GUILayoutOption[] options)
         {
             var smartVal = GetSmartValue();

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Members/BoolDrawableField.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Members/BoolDrawableField.cs
@@ -9,29 +9,17 @@ namespace Rhinox.GUIUtils.Editor
 {
     public class BoolDrawableField : BaseMemberDrawable<bool>
     {
-        private bool _left;
-        
         public BoolDrawableField(GenericMemberEntry entry) : base(entry)
         {
         }
 
-        protected override void Initialize()
-        {
-            _left = GetDrawableAttribute<ToggleLeftAttribute>() != null;
-            base.Initialize();
-        }
-
         protected override bool DrawValue(GUIContent label, bool val, params GUILayoutOption[] options)
         {
-            if (_left)
-                return EditorGUILayout.ToggleLeft(label, val, CustomGUIStyles.CleanLabelField, options);
             return EditorGUILayout.Toggle(label, val, CustomGUIStyles.CleanLabelField, options);
         }
 
         protected override bool DrawValue(Rect rect, GUIContent label, bool val)
         {
-            if (_left)
-                return EditorGUI.ToggleLeft(rect, label, val);
             return EditorGUI.Toggle(rect, label, val);
         }
     }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/SmartPropertyView.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/SmartPropertyView.cs
@@ -23,7 +23,7 @@ namespace Rhinox.GUIUtils.Editor
             _propertyTree = PropertyTree.Create(instance);
             _allowUndo = instance is UnityEngine.Object;
 #else
-            _odinlessDrawer = new DrawablePropertyView(instance, false);
+            _odinlessDrawer = new DrawablePropertyView(instance);
 #endif
         }
 
@@ -33,7 +33,7 @@ namespace Rhinox.GUIUtils.Editor
             _propertyTree = PropertyTree.Create(serializedObject);
             _allowUndo = true;
 #else
-            _odinlessDrawer = new DrawablePropertyView(serializedObject, false);
+            _odinlessDrawer = new DrawablePropertyView(serializedObject);
 #endif
         }
 

--- a/Assets/GUIUtils/Editor/GUI/Drawables/SmartPropertyView.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/SmartPropertyView.cs
@@ -8,11 +8,14 @@ namespace Rhinox.GUIUtils.Editor
     public class SmartPropertyView
     {
 #if ODIN_INSPECTOR
+        public bool ShouldRepaint => false;
         private readonly PropertyTree _propertyTree;
         private readonly bool _allowUndo;
 #else
+        public bool ShouldRepaint => _odinlessDrawer.ShouldRepaint;
         private readonly DrawablePropertyView _odinlessDrawer;
 #endif
+
         
         public SmartPropertyView(object instance)
         {
@@ -33,7 +36,7 @@ namespace Rhinox.GUIUtils.Editor
             _odinlessDrawer = new DrawablePropertyView(serializedObject, false);
 #endif
         }
-        
+
         public void DrawLayout()
         {
 #if ODIN_INSPECTOR

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/BaseWrapperDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/BaseWrapperDrawable.cs
@@ -24,6 +24,19 @@ namespace Rhinox.GUIUtils.Editor
             Order = _innerDrawable.Order;
         }
 
+        private bool _localShouldRepaint;
+        public override bool ShouldRepaint
+        {
+            get
+            {
+                return _localShouldRepaint || _innerDrawable.ShouldRepaint;
+            }
+            protected set
+            {
+                _localShouldRepaint = value;
+            }
+        }
+
         public override IEnumerable<TAttribute> GetDrawableAttributes<TAttribute>()
         {
             return _innerDrawable.GetDrawableAttributes<TAttribute>();
@@ -40,6 +53,12 @@ namespace Rhinox.GUIUtils.Editor
         protected override void DrawInner(Rect rect, GUIContent label)
         {
             _innerDrawable.Draw(rect, label);
+        }
+
+        protected override void OnPreDraw()
+        {
+            base.OnPreDraw();
+            _localShouldRepaint = false;
         }
     }
 }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/BaseWrapperDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/BaseWrapperDrawable.cs
@@ -42,9 +42,6 @@ namespace Rhinox.GUIUtils.Editor
             return _innerDrawable.GetDrawableAttributes<TAttribute>();
         }
         
-        // Sealed because you need to override the GUILayoutOption one
-        protected sealed override void DrawInner(GUIContent label) => DrawInner(label, Array.Empty<GUILayoutOption>());
-
         protected override void DrawInner(GUIContent label, params GUILayoutOption[] options)
         {
             _innerDrawable.Draw(label, options);

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/DrawAsUnityObjectWrapper.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/DrawAsUnityObjectWrapper.cs
@@ -1,0 +1,28 @@
+﻿using Rhinox.GUIUtils.Attributes;
+using UnityEditor;
+using UnityEngine;
+
+namespace Rhinox.GUIUtils.Editor
+{
+    // TODO: how do we support this
+    // public class DrawAsUnityObjectWrapper : BaseWrapperDrawable
+    // {
+    //     public DrawAsUnityObjectWrapper(IOrderedDrawable drawable) : base(drawable)
+    //     {
+    //     }
+    //
+    //     protected override void DrawInner(Rect rect, GUIContent label)
+    //     {
+    //         EditorGUI.ObjectField(rect, label, (UnityEngine.Object) Host, typeof(UnityEngine.Object));
+    //     }
+    //     
+    //     
+    //     [WrapDrawer(typeof(DrawAsUnityObjectAttribute))]
+    //     public static BaseWrapperDrawable Create(DrawAsUnityObjectAttribute attr, IOrderedDrawable drawable)
+    //     {
+    //         return new DrawAsUnityObjectWrapper(drawable)
+    //         {
+    //         };
+    //     }
+    // }
+}

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/DrawAsUnityObjectWrapper.cs.meta
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/DrawAsUnityObjectWrapper.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9044a59b694e48c09c88b5fd671a8bb3
+timeCreated: 1680699989

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/DropdownWrapper.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/DropdownWrapper.cs
@@ -130,7 +130,7 @@ namespace Rhinox.GUIUtils.Editor
             _valueChanged = true;
         }
 
-        [WrapDrawer(typeof(ValueDropdownAttribute))]
+        [WrapDrawer(typeof(ValueDropdownAttribute), -1)]
         public static BaseWrapperDrawable Create(ValueDropdownAttribute attr, IOrderedDrawable drawable)
         {
             var member = MemberHelper.Create<IEnumerable>(drawable.Host, attr.MemberName);

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/GUIStateWrapper.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/GUIStateWrapper.cs
@@ -16,7 +16,7 @@ namespace Rhinox.GUIUtils.Editor
 
         protected override void OnPreDraw()
         {
-            _stateMember.DrawError();
+            _stateMember?.DrawError();
             
             _previousState = GUI.enabled;
 

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/HideWrapper.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/HideWrapper.cs
@@ -8,7 +8,7 @@ namespace Rhinox.GUIUtils.Editor
         private bool _state;
 
         private IPropertyMemberHelper<bool> _stateMember;
-        
+
         public override bool IsVisible => _innerDrawable.IsVisible && ShouldDraw();
 
         public HideWrapper(IOrderedDrawable drawable) : base(drawable)
@@ -35,7 +35,6 @@ namespace Rhinox.GUIUtils.Editor
             if (_stateMember == null)
                 return _state;
             
-            _stateMember.DrawError();
             return _stateMember.GetValue() == _state;
         }
 

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/NullReferenceDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/NullReferenceDrawable.cs
@@ -84,9 +84,7 @@ namespace Rhinox.GUIUtils.Editor
 
         private void UpdateInnerDrawable()
         {
-            var hostInfo = _serializedProperty.GetHostInfo();
-            var type = hostInfo.GetReturnType();
-            _innerDrawable = DrawableFactory.CreateDrawableFor(_serializedProperty, type);
+            _innerDrawable = DrawableFactory.CreateDrawableFor(_serializedProperty);
         }
 
         GUIContent GetTypeName(SerializedProperty property)

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/NullReferenceDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/NullReferenceDrawable.cs
@@ -86,9 +86,7 @@ namespace Rhinox.GUIUtils.Editor
         {
             var hostInfo = _serializedProperty.GetHostInfo();
             var type = hostInfo.GetReturnType();
-            var drawables = DrawableFactory.CreateDrawableMembersFor(_serializedProperty, type);
-            var group = GroupingHelper.Process(drawables);
-            _innerDrawable = group;
+            _innerDrawable = DrawableFactory.CreateDrawableFor(_serializedProperty, type);
         }
 
         GUIContent GetTypeName(SerializedProperty property)

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/ToggleLeftWrapper.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/ToggleLeftWrapper.cs
@@ -1,0 +1,42 @@
+﻿using Rhinox.Lightspeed;
+using Sirenix.OdinInspector;
+using UnityEditor;
+using UnityEngine;
+
+namespace Rhinox.GUIUtils.Editor
+{
+    public class ToggleLeftWrapper : BaseWrapperDrawable
+    {
+        private readonly float _toggleWidth = EditorGUIUtility.singleLineHeight + CustomGUIUtility.Padding;
+        
+        public ToggleLeftWrapper(IOrderedDrawable drawable) : base(drawable)
+        {
+        }
+        
+        protected override void DrawInner(GUIContent label, params GUILayoutOption[] options)
+        {
+            EditorGUILayout.BeginHorizontal();
+            base.DrawInner(GUIContent.none, options.Append(GUILayout.MaxWidth(_toggleWidth)));
+            EditorGUILayout.LabelField(label);
+            EditorGUILayout.EndHorizontal();
+        }
+
+        protected override void DrawInner(Rect rect, GUIContent label)
+        {
+            var toggleRect = rect.AlignLeft(_toggleWidth);
+            base.DrawInner(toggleRect, GUIContent.none);
+            var labelRect = rect;
+            labelRect.width -= toggleRect.width;
+            labelRect.x += toggleRect.width;
+            EditorGUI.LabelField(labelRect, label);
+        }
+
+        [WrapDrawer(typeof(ToggleLeftAttribute))]
+        public static BaseWrapperDrawable Create(ToggleLeftAttribute attr, IOrderedDrawable drawable)
+        {
+            return new ToggleLeftWrapper(drawable)
+            {
+            };
+        }
+    }
+}

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/ToggleLeftWrapper.cs.meta
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/ToggleLeftWrapper.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e30c271089af402a91842e2a9ee1970f
+timeCreated: 1680768391

--- a/Assets/GUIUtils/Editor/Helpers/MemberHelpers/GenericElementMemberEntry.cs
+++ b/Assets/GUIUtils/Editor/Helpers/MemberHelpers/GenericElementMemberEntry.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections;
+using System.Reflection;
 using Rhinox.Lightspeed.Reflection;
+using Sirenix.OdinInspector;
 
 namespace Rhinox.GUIUtils.Editor
 {
@@ -8,29 +10,36 @@ namespace Rhinox.GUIUtils.Editor
     {
         public int Index;
         private Type _elementType;
-        
+        private readonly GenericHostInfo _hostInfo;
+
         public GenericElementMemberEntry(GenericMemberEntry listEntry, int index)
             : base(listEntry.Instance, listEntry.Info, listEntry)
         {
+            _hostInfo = new GenericHostInfo(listEntry.Instance, listEntry.Info as FieldInfo, index);
             Index = index;
             _elementType = Info.GetReturnType().GetCollectionElementType();
         }
 
-        public override Attribute[] GetAttributes() => Array.Empty<Attribute>();
+        public override Attribute[] GetAttributes() => new []{ new HideLabelAttribute()};
 
         public override Type GetReturnType() => _elementType;
 
         public override object GetValue()
         {
-            var list = (IList) Parent.GetValue();
-            return list[Index];
+            if (_hostInfo != null)
+                return _hostInfo.GetValue();
+            return base.GetValue();
         }
 
         public override bool TrySetValue<T>(T val)
         {
-            var list = (IList) Parent.GetValue();
-            list[Index] = val;
-            return true;
+            if (_hostInfo != null)
+            {
+                _hostInfo.SetValue(val);
+                return true;
+            }
+
+            return base.TrySetValue(val);
         }
     }
 }

--- a/Assets/GUIUtils/Editor/Helpers/MemberHelpers/GenericElementMemberEntry.cs
+++ b/Assets/GUIUtils/Editor/Helpers/MemberHelpers/GenericElementMemberEntry.cs
@@ -15,8 +15,8 @@ namespace Rhinox.GUIUtils.Editor
         public GenericElementMemberEntry(GenericMemberEntry listEntry, int index)
             : base(listEntry.Instance, listEntry.Info, listEntry)
         {
-            _hostInfo = new GenericHostInfo(listEntry.Instance, listEntry.Info as FieldInfo, index);
             Index = index;
+            _hostInfo = new GenericHostInfo(listEntry.Instance, listEntry.Info as FieldInfo, Index);
             _elementType = Info.GetReturnType().GetCollectionElementType();
         }
 

--- a/Assets/GUIUtils/Editor/Helpers/MemberHelpers/GenericElementMemberEntry.cs
+++ b/Assets/GUIUtils/Editor/Helpers/MemberHelpers/GenericElementMemberEntry.cs
@@ -22,13 +22,13 @@ namespace Rhinox.GUIUtils.Editor
 
         public override object GetValue()
         {
-            var list = Parent.GetValue() as IList;
+            var list = (IList) Parent.GetValue();
             return list[Index];
         }
 
         public override bool TrySetValue<T>(T val)
         {
-            var list = Parent.GetValue() as IList;
+            var list = (IList) Parent.GetValue();
             list[Index] = val;
             return true;
         }

--- a/Assets/GUIUtils/Editor/Helpers/MemberHelpers/GenericElementMemberEntry.cs
+++ b/Assets/GUIUtils/Editor/Helpers/MemberHelpers/GenericElementMemberEntry.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections;
+using Rhinox.Lightspeed.Reflection;
+
+namespace Rhinox.GUIUtils.Editor
+{
+    public class GenericElementMemberEntry : GenericMemberEntry
+    {
+        public int Index;
+        private Type _elementType;
+        
+        public GenericElementMemberEntry(GenericMemberEntry listEntry, int index)
+            : base(listEntry.Instance, listEntry.Info, listEntry)
+        {
+            Index = index;
+            _elementType = Info.GetReturnType().GetCollectionElementType();
+        }
+
+        public override Attribute[] GetAttributes() => Array.Empty<Attribute>();
+
+        public override Type GetReturnType() => _elementType;
+
+        public override object GetValue()
+        {
+            var list = Parent.GetValue() as IList;
+            return list[Index];
+        }
+
+        public override bool TrySetValue<T>(T val)
+        {
+            var list = Parent.GetValue() as IList;
+            list[Index] = val;
+            return true;
+        }
+    }
+}

--- a/Assets/GUIUtils/Editor/Helpers/MemberHelpers/GenericElementMemberEntry.cs.meta
+++ b/Assets/GUIUtils/Editor/Helpers/MemberHelpers/GenericElementMemberEntry.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ba729b317e484d1e846a44027c46795b
+timeCreated: 1680600134

--- a/Assets/GUIUtils/Editor/Helpers/MemberHelpers/GenericMemberEntry.cs
+++ b/Assets/GUIUtils/Editor/Helpers/MemberHelpers/GenericMemberEntry.cs
@@ -21,9 +21,9 @@ namespace Rhinox.GUIUtils.Editor
             Info = info;
         }
 
-        public Type GetReturnType() => Info.GetReturnType();
+        public virtual Type GetReturnType() => Info.GetReturnType();
 
-        public Attribute[] GetAttributes()
+        public virtual Attribute[] GetAttributes()
         {
             var directAttr = Info.GetCustomAttributes();
             if (Instance == null)
@@ -36,10 +36,10 @@ namespace Rhinox.GUIUtils.Editor
         public T GetAttribute<T>() where T : Attribute
             => GetAttributes().OfType<T>().FirstOrDefault();
 
-        public object GetValue() => Info.GetValue(Instance);
+        public virtual object GetValue() => Info.GetValue(Instance);
 
         public T GetSmartValue<T>() => (T) GetValue();
 
-        public bool TrySetValue<T>(T val) => Info.TrySetValue(Instance, val);
+        public virtual bool TrySetValue<T>(T val) => Info.TrySetValue(Instance, val);
     }
 }

--- a/Assets/GUIUtils/Editor/Helpers/MemberHelpers/GenericPropertyMemberHelper.cs
+++ b/Assets/GUIUtils/Editor/Helpers/MemberHelpers/GenericPropertyMemberHelper.cs
@@ -73,7 +73,6 @@ namespace Rhinox.GUIUtils.Editor
             const string ROOT_ID = "root";
             const string PROPERTY_ID = "property";
             
-            int partI = -1;
             GenericMemberEntry usedEntry = null;
             string[] parts = input.Split(new[] { "." }, StringSplitOptions.RemoveEmptyEntries);
             for (int i = 0; i < parts.Length; ++i)

--- a/Assets/GUIUtils/Editor/Helpers/MemberHelpers/SerializedPropertyMemberHelper.cs
+++ b/Assets/GUIUtils/Editor/Helpers/MemberHelpers/SerializedPropertyMemberHelper.cs
@@ -11,23 +11,17 @@ namespace Rhinox.GUIUtils.Editor
     /// VERY BASIC VERSION OF PropertyMemberHelper FOR WHEN NO ACCESS TO ODIN
     /// Helper class to handle strings for labels and other similar purposes.
     /// Allows for a static string, or for referring to string member fields, properties or methods, by name
+    /// Support special cases: $root, $parent, $property
     /// </summary>
     public class SerializedPropertyMemberHelper<T> : BaseValueMemberHelper<T>, IPropertyMemberHelper<T>
     {
         private HostInfo _info;
 
-        /// <summary>Creates a StringMemberHelper to get a display string.</summary>
-        /// <param name="property">Inspector property to get string from.</param>
-        /// <param name="input">The input string. If the first character is a '$', then StringMemberHelper will look for a member string field, property or method, and will try to parse it as an expression if it starts with '@'.</param>
         public SerializedPropertyMemberHelper(SerializedProperty property, string input)
             : this(property.serializedObject == null, input, property)
         {
         }
 
-        /// <summary>Creates a StringMemberHelper to get a display string.</summary>
-        /// <param name="property">Inspector property to get string from.</param>
-        /// <param name="input">The input string. If the first character is a '$', then StringMemberHelper will look for a member string field, property or method, and will try to parse it as an expression if it starts with '@'.</param>
-        /// /// <param name="input">The input string. If the first character is a '$', then StringMemberHelper will look for a member string field, property or method.</param>
         public SerializedPropertyMemberHelper(SerializedProperty property, string input, ref string errorMessage)
             : this(property, input)
         {
@@ -36,11 +30,6 @@ namespace Rhinox.GUIUtils.Editor
             errorMessage = this.ErrorMessage;
         }
         
-        /// <summary>Creates a StringMemberHelper to get a display string.</summary>
-        /// <param name="objectType">The type of the parent, to get a member string from.</param>
-        /// <param name="isStatic">Value indicating if the context should be static.</param>
-        /// <param name="input">The input string. If the first character is a '$', then StringMemberHelper will look for a member string field, property or method, and will try to parse it as an expression if it starts with '@'.</param>
-        /// /// <param name="input">The input string. If the first character is a '$', then StringMemberHelper will look for a member string field, property or method.</param>
         private SerializedPropertyMemberHelper(bool isStatic, string input, SerializedProperty property)
         {
             _objectType = property.GetHostType();
@@ -70,6 +59,7 @@ namespace Rhinox.GUIUtils.Editor
             
             const string PARENT_ID = "parent";
             const string ROOT_ID = "root";
+            const string PROPERTY_ID = "property";
 
             int partI = -1;
             while ((partI = input.IndexOf(".", StringComparison.Ordinal)) >= 0)
@@ -84,6 +74,8 @@ namespace Rhinox.GUIUtils.Editor
                     case ROOT_ID:
                         while (_info.Parent != null)
                             _info = _info.Parent;
+                        break;
+                    case PROPERTY_ID:
                         break;
                     default:
                         actionTaken = false;

--- a/Assets/GUIUtils/Editor/Windows/CustomEditorWindow.cs
+++ b/Assets/GUIUtils/Editor/Windows/CustomEditorWindow.cs
@@ -12,7 +12,7 @@ using Object = UnityEngine.Object;
 
 namespace Rhinox.GUIUtils.Editor
 {
-    public class CustomEditorWindow : EditorWindow, ISerializationCallbackReceiver
+    public class CustomEditorWindow : EditorWindow, ISerializationCallbackReceiver, IRepaintRequest
     {
         /// <summary>
         /// Gets the label width to be used. Values between 0 and 1 are treated as percentages, and values above as pixels.
@@ -581,7 +581,11 @@ namespace Rhinox.GUIUtils.Editor
             {
                 UnityEditor.Editor editor = _editors[index];
                 if (editor != null && editor.target != null)
+                {
+                    if (editor is IRepaintRequestHandler handler)
+                        handler.UpdateRequestTarget(this);
                     editor.OnInspectorGUI();
+                }
 
                 if (DrawUnityEditorPreview)
                     DrawEditorPreview(index, _defaultEditorPreviewHeight);
@@ -614,7 +618,7 @@ namespace Rhinox.GUIUtils.Editor
         {
         }
         
-        protected void RequestRepaint()
+        public void RequestRepaint()
         {
             _repaintRequested = true;
         }

--- a/Assets/GUIUtils/Editor/Windows/CustomEditorWindow.cs
+++ b/Assets/GUIUtils/Editor/Windows/CustomEditorWindow.cs
@@ -591,6 +591,10 @@ namespace Rhinox.GUIUtils.Editor
                     DrawEditorPreview(index, _defaultEditorPreviewHeight);
 
             }
+            catch (ExitGUIException)
+            {
+                // Do nothing, this is supported behaviour
+            }
             catch (Exception e)
             {
                 EditorGUILayout.HelpBox(e.ToString(), MessageType.Error);

--- a/Assets/GUIUtils/GUI/GUIContentHelper.cs
+++ b/Assets/GUIUtils/GUI/GUIContentHelper.cs
@@ -10,6 +10,7 @@ namespace Rhinox.GUIUtils
         private static readonly GUIContent _tempContent = new GUIContent("");
         
         private static readonly GUIFrameAwareStack<Color> ColorStack = new GUIFrameAwareStack<Color>();
+        private static readonly GUIFrameAwareStack<Color> BackgroundColorStack = new GUIFrameAwareStack<Color>();
         private static readonly GUIFrameAwareStack<bool> GuiEnabled = new GUIFrameAwareStack<bool>();
 
 #if UNITY_EDITOR
@@ -126,6 +127,17 @@ namespace Rhinox.GUIUtils
         public static void PopColor()
         {
             GUI.color = GUIContentHelper.ColorStack.Pop();
+        }
+        
+        public static void PushBackgroundColor(Color color)
+        {
+            GUIContentHelper.BackgroundColorStack.Push(GUI.color);
+            GUI.backgroundColor = color;
+        }
+        
+        public static void PopBackgroundColor()
+        {
+            GUI.backgroundColor = GUIContentHelper.BackgroundColorStack.Pop();
         }
         
         public static void PushDisabled(bool disabled)

--- a/Assets/GUIUtils/GUI/GUIContentHelper.cs
+++ b/Assets/GUIUtils/GUI/GUIContentHelper.cs
@@ -104,6 +104,18 @@ namespace Rhinox.GUIUtils
         
         // =============================================================================================================
         // General helpers
+
+        private static bool _repaintRequested;
+        public static void RequestRepaint()
+        {
+            _repaintRequested = true;
+            
+        }
+
+        public static bool ShouldRepaint()
+        {
+            return _repaintRequested;
+        }
         
         public static void PushColor(Color color)
         {

--- a/Assets/GUIUtils/GUI/GUIContentHelper.cs
+++ b/Assets/GUIUtils/GUI/GUIContentHelper.cs
@@ -105,18 +105,6 @@ namespace Rhinox.GUIUtils
         
         // =============================================================================================================
         // General helpers
-
-        private static bool _repaintRequested;
-        public static void RequestRepaint()
-        {
-            _repaintRequested = true;
-            
-        }
-
-        public static bool ShouldRepaint()
-        {
-            return _repaintRequested;
-        }
         
         public static void PushColor(Color color)
         {


### PR DESCRIPTION
### Added
- Repaint system in IOrderedDrawables and DrawablePropertyView (automatically leveraged in CustomEditorWindow)
- SerializedObjectExtensions.GetAttributes: fetch attributes collection on SerializedProperty instances
- GUIContentHelper.PushBackgroundColor/PopBackgroundColor
- ToggleLeftWrapper: for prefixing the value to the label in a generic way
- GenericElementMemberEntry: inherited class rom GenericMemberEntry to handle collection entry drawing

### Modified
- BetterReorderableList: changed drawing styling
- PageableReorderableList now uses GenericMemberEntry in its constructor instead of direct object reference
- BaseDrawable no longer has a member DrawInner(GUIContent label) now only the version with GUILayoutOptions remains
- Large rework of the PropertyGroupDrawable system: added BaseHorizontalGroupDrawable, BaseVerticalGroupDrawable to leverage grouping behaviours generally
- Added ButtonGroupDrawable 
- Can now override Attribute based methods and properties on CompositeDrawableMember
- ObjectCompositeDrawableMember  no longer inherits from VerticalGroupDrawable, CompositeDrawableMember instead
- DrawablePropertyView: large cleanup, constructors are now more clearly defined with better paths into DrawableFactory
- DrawableList no longer handles DrawAsUnityObjectAttribute
- DrawableList handles GenericMemberEntry instead of generic object reference in its constructor
- HideWrapper no longer draw error boxes on ShouldDraw() method
- HostInfo split into HostInfo (for serializedobjects) and GenericHostInfo (for generic instances)
- CustomEditorWindow.DrawEditor: added exception fall through for ExitGUIException (does not need be logged)

### Fixed
- Adding entry to BetterReorderableList when base type is UnityEngine.Object: now inject null 
- IndexOutOfRangeException when removing an entry from PageableReorderableList which causes one less page to draw
- Some Drawables did not handle GUILayoutOptions: fixed with refactor of BaseDrawable
- Fixed repaint not triggering when adding a new element to DrawableList
- NullReferenceException on GUIStateWrapper.OnPreDraw
