### PR TITLE
Fix/draw as string shenanigans

### DIFF
--- a/Assets/GUIUtils/Attributes/DisplayAsStringAlignedAttribute.cs
+++ b/Assets/GUIUtils/Attributes/DisplayAsStringAlignedAttribute.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Sirenix.OdinInspector;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Rhinox.GUIUtils.Attributes
+{
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = false, Inherited = true)] 
+    public class DisplayAsStringAlignedAttribute : PropertyAttribute
+    {
+        public TextAlignment Alignment { get; }
+        
+        public bool Overflow { get; }
+
+        public DisplayAsStringAlignedAttribute(bool overflow = true)
+        {
+            Alignment = TextAlignment.Left;
+            Overflow = overflow;
+        }
+
+        public DisplayAsStringAlignedAttribute(TextAlignment alignment, bool overflow = true)
+        {
+            Alignment = alignment;
+            Overflow = overflow;
+        }
+    }
+}

--- a/Assets/GUIUtils/Attributes/DisplayAsStringAlignedAttribute.cs.meta
+++ b/Assets/GUIUtils/Attributes/DisplayAsStringAlignedAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2e4683480e8e4fe7ac5b0ff1033ce2a0
+timeCreated: 1681375347

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Entities/BaseEntityDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Entities/BaseEntityDrawable.cs
@@ -2,24 +2,41 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Rhinox.Lightspeed.Reflection;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
+using Object = System.Object;
 
 namespace Rhinox.GUIUtils.Editor
 {
     public abstract class BaseEntityDrawable<T> : BaseEntityDrawable
     {
-        protected T Entity => (T) EntityInstance;
-        
-        protected BaseEntityDrawable(T instanceVal, MemberInfo memberInfo = null) : base(instanceVal, memberInfo)
+        public T Entity => (T) Instance;
+
+        public override Type ObjectType => typeof(T);
+
+        protected BaseEntityDrawable(T instanceVal, MemberInfo memberInfo = null) 
+            : base(instanceVal, memberInfo)
         {
         }
     }
     
-    public abstract class BaseEntityDrawable : BaseDrawable
+    public abstract class BaseEntityDrawable : BaseDrawable, IObjectDrawable
     {
-        protected object EntityInstance { get; }
+        public object Instance { get; }
+
+        public virtual Type ObjectType
+        {
+            get
+            {
+                if (Instance != null)
+                    return Instance.GetType();
+                if (_memberInfo != null)
+                    _memberInfo.GetReturnType();
+                return typeof(System.Object);
+            }
+        }
         protected readonly MemberInfo _memberInfo;
 
         public override string LabelString => Host?.GetType().Name;
@@ -34,7 +51,7 @@ namespace Rhinox.GUIUtils.Editor
         protected BaseEntityDrawable(object instanceVal, MemberInfo memberInfo = null)
         {
             Host = null;
-            EntityInstance = instanceVal;
+            Instance = instanceVal;
             _memberInfo = memberInfo;
         }
     }

--- a/Assets/GUIUtils/GUI/CustomGUIStyles.cs
+++ b/Assets/GUIUtils/GUI/CustomGUIStyles.cs
@@ -246,6 +246,23 @@ namespace Rhinox.GUIUtils
             }
         }
         
+        private static GUIStyle _labelStyleRight;
+        public static GUIStyle LabelRight
+        {
+            get
+            {
+                if (_labelStyleRight == null)
+                {
+                    _labelStyleRight = new GUIStyle(CustomGUIStyles.Label)
+                    {
+                        alignment = TextAnchor.MiddleRight
+                    };
+                }
+
+                return _labelStyleRight;
+            }
+        }
+        
         private static GUIStyle _labelStyleCenteredWithHover;
         public static GUIStyle CenteredLabelWithHover
         {

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/DrawAsStringAlignedAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/DrawAsStringAlignedAttributeDrawer.cs
@@ -1,0 +1,69 @@
+﻿using Rhinox.GUIUtils.Attributes;
+using Sirenix.OdinInspector;
+using Sirenix.OdinInspector.Editor;
+using Sirenix.Utilities;
+using Sirenix.Utilities.Editor;
+using UnityEditor;
+using UnityEngine;
+
+namespace Rhinox.GUIUtils.Odin.Editor
+{
+    public class DrawAsStringAlignedAttributeDrawer<T> : OdinAttributeDrawer<DisplayAsStringAlignedAttribute, T>
+    {
+        private GUIStyle _currentLabelStyle;
+
+        protected override void DrawPropertyLayout(GUIContent label)
+        {
+            IPropertyValueEntry<T> valueEntry = this.ValueEntry;
+            DisplayAsStringAlignedAttribute attribute = this.Attribute;
+            if (valueEntry.Property.ChildResolver is ICollectionResolver)
+            {
+                this.CallNextDrawer(label);
+            }
+            else
+            {
+                string str = (object) valueEntry.SmartValue == null ? "Null" : valueEntry.SmartValue.ToString();
+                if (label == null)
+                    EditorGUILayout.LabelField(str, GetStyle(Attribute.Alignment), (GUILayoutOption[]) GUILayoutOptions.MinWidth(0.0f));
+                else if (!attribute.Overflow)
+                {
+                    GUIContent content = GUIHelper.TempContent(str);
+                    GUI.Label(
+                        EditorGUI.PrefixLabel(
+                            EditorGUILayout.GetControlRect(false, 
+                                SirenixGUIStyles.MultiLineLabel.CalcHeight(content, valueEntry.Property.LastDrawnValueRect.width - GUIHelper.BetterLabelWidth), 
+                                (GUILayoutOption[]) GUILayoutOptions.MinWidth(0.0f)), label), 
+                        content, 
+                        GetStyle(Attribute.Alignment));
+                }
+                else
+                {
+                    Rect valueRect;
+                    SirenixEditorGUI.GetFeatureRichControlRect(label, out int _, out bool _, out valueRect);
+                    GUI.Label(valueRect, str, GetStyle(Attribute.Alignment));
+                }
+            }
+        }
+        
+        private GUIStyle GetStyle(TextAlignment alignment)
+        {
+            if (_currentLabelStyle == null)
+            {
+                GUIStyle labelStyle = Attribute.Overflow ? CustomGUIStyles.Label : SirenixGUIStyles.MultiLineLabel;
+                labelStyle = new GUIStyle(labelStyle);
+                switch (alignment)
+                {
+                    case TextAlignment.Center:
+                        labelStyle.alignment = TextAnchor.MiddleCenter;
+                        break;
+                    case TextAlignment.Right:
+                        labelStyle.alignment = TextAnchor.MiddleRight;
+                        break;
+                }
+                _currentLabelStyle = labelStyle;
+            }
+
+            return _currentLabelStyle;
+        }
+    }
+}

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/DrawAsStringAlignedAttributeDrawer.cs.meta
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/DrawAsStringAlignedAttributeDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fa962404c7b046139b3128ecc5c8a4d1
+timeCreated: 1681377759

--- a/Assets/GUIUtils/package.json
+++ b/Assets/GUIUtils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.rhinox.open.guiutils",
   "displayName": "GUIUtils - Editor Graphical UI Extensions",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "unity": "2019.4",
   "description": "GUI Utils for Unity projects, mostly Editor extensions. (Optional Odin extensions)",
   "keywords": [


### PR DESCRIPTION
### Added
- DisplayAsStringAlignedAttribute: Alternative to DisplayAsStringAttribute that allows TextAlignment setting
- CustomGUIStyles.LabelRight: Right aligned Label style
### Modified
- DisplayAsStringWrapper: Now handles Overflow

### Fix
- BaseEntityDrawable now implements IObjectDrawable, which fixes DrawAsString not working for EntityDrawables