### PR TITLE
[ADD] IsMask boolean to layer and fixed bug in navmeshAttribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ Packages/packages-lock.json
 
 # Logs
 Logs/*.log
+*.vsconfig

--- a/Assets/GUIUtils/Attributes/LayerAttribute.cs
+++ b/Assets/GUIUtils/Attributes/LayerAttribute.cs
@@ -7,6 +7,12 @@ namespace Rhinox.GUIUtils.Attributes
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
     [Conditional("UNITY_EDITOR")]
     public class LayerAttribute : PropertyAttribute
-    { 
+    {
+        public bool IsMask { get; }
+
+        public LayerAttribute(bool mask = false)
+        {
+            IsMask = mask;
+        }
     }
 }

--- a/Assets/GUIUtils/Editor/Drawers/LayerAttributeDrawer.cs
+++ b/Assets/GUIUtils/Editor/Drawers/LayerAttributeDrawer.cs
@@ -1,13 +1,22 @@
 using Rhinox.GUIUtils.Attributes;
 using Rhinox.Lightspeed.Reflection;
+using Rhinox.GUIUtils.Utils;
 using UnityEditor;
 using UnityEngine;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine.AI;
+using UnityEditor.UIElements;
+using Rhinox.Lightspeed;
 
 namespace Rhinox.GUIUtils.Editor
 {
     [CustomPropertyDrawer(typeof(LayerAttribute))]
     public class LayerAttributeDrawer : PropertyDrawer
     {
+        //private Dictionary<int, string> _layerNameByIndex;
+        private List<KeyValuePair<int, string>> _layerNameByIndex = new List<KeyValuePair<int, string>>();
+
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
             if (fieldInfo.GetReturnType() != typeof(int))
@@ -15,8 +24,78 @@ namespace Rhinox.GUIUtils.Editor
                 base.OnGUI(position, property, label);
                 return;
             }
-            
-            property.intValue = EditorGUI.LayerField(position, label, property.intValue);
+
+            var options = LayerUtils.GetLayerNames();
+            _layerNameByIndex = options.Select(x => new KeyValuePair<int, string>(LayerMask.NameToLayer(x), x)).ToList();
+
+            if (((LayerAttribute)attribute).IsMask)
+            {
+                int convertedMask = 0;
+                if (property.intValue != 0)
+                {
+                    for (int index = 0; index < 32; index++)
+                    {
+                        if ((property.intValue >> index & 1) == 1)
+                        {
+                            convertedMask |= 1 << _layerNameByIndex.FindIndex(x => x.Key == index);
+
+                            property.intValue -= 1 << index;
+                            if (property.intValue == 0)
+                                break;
+                        }
+                    }
+                }
+
+                convertedMask = EditorGUI.MaskField(position, label, convertedMask, options);
+
+                property.intValue = 0;
+                if (convertedMask != 0)
+                {
+                    for (int index = 0; index < _layerNameByIndex.Count; index++)
+                    {
+                        if ((convertedMask >> index & 1) == 1)
+                        {
+                            property.intValue |= 1 << _layerNameByIndex[index].Key;
+
+                            convertedMask -= 1 << index;
+                            if (convertedMask == 0)
+                                break;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                var result = _layerNameByIndex.FirstOrDefault(x => x.Key == property.intValue);
+                string dropDownText;
+                if (!result.IsDefault())
+                {
+                    dropDownText = result.Value;
+                }
+                else
+                {
+                    dropDownText = "<Select a value>";
+                    property.intValue = -1;
+                }
+
+                EditorGUILayout.BeginHorizontal();
+                var controlRect = EditorGUI.PrefixLabel(position, label);
+                if (EditorGUI.DropdownButton(controlRect, GUIContentHelper.TempContent(dropDownText), FocusType.Passive, EditorStyles.miniPullDown))
+                {
+                    var menu = new GenericMenu();
+
+                    foreach (var option in options)
+                    {
+                        menu.AddItem(new GUIContent(option), false, () =>
+                        {
+                            property.intValue = LayerMask.NameToLayer(option);
+                            property.serializedObject.ApplyModifiedProperties();
+                        });
+                    }
+                    menu.DropDown(controlRect);
+                }
+                EditorGUILayout.EndHorizontal();
+            }
         }
     }
 }

--- a/Assets/GUIUtils/Editor/Drawers/NavMeshAreaAttributeDrawer.cs
+++ b/Assets/GUIUtils/Editor/Drawers/NavMeshAreaAttributeDrawer.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Rhinox.GUIUtils.Attributes;
 using Rhinox.Lightspeed;
 using Rhinox.Lightspeed.Reflection;
@@ -23,9 +22,9 @@ namespace Rhinox.GUIUtils.Editor
                 return;
             }
 
-            //this can props be optimized by caching the values, but
-            //If the navmesh area list change, the cache has to be update,
-            //and i don't know if there is an event for when that updates
+            //I recreate the list instead of caching it.
+            //If the navmesh area list changes (add,remove or rename), then the cache will be stale.
+            //Beacuse there is (AFAIK) no direct method when the Navmesh area names update.
             var options = GameObjectUtility.GetNavMeshAreaNames();
             _areaNameByIndex = options.Select(x => new KeyValuePair<int, string>(NavMesh.GetAreaFromName(x), x)).ToList();
 
@@ -87,7 +86,7 @@ namespace Rhinox.GUIUtils.Editor
 
                     foreach (var option in options)
                     {
-                        menu.AddItem(new GUIContent(option), false, () =>
+                        menu.AddItem(new GUIContent(option), dropDownText.Equals(option), () =>
                         {
                             property.intValue = NavMesh.GetAreaFromName(option);
                             property.serializedObject.ApplyModifiedProperties();

--- a/Assets/GUIUtils/Editor/Drawers/NavMeshAreaAttributeDrawer.cs
+++ b/Assets/GUIUtils/Editor/Drawers/NavMeshAreaAttributeDrawer.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Reflection;
 using Rhinox.GUIUtils.Attributes;
+using Rhinox.Lightspeed;
 using Rhinox.Lightspeed.Reflection;
 using UnityEditor;
 using UnityEngine;
@@ -12,8 +13,8 @@ namespace Rhinox.GUIUtils.Editor
     [CustomPropertyDrawer(typeof(NavMeshAreaAttribute))]
     public class NavMeshLayerAttributeDrawer : PropertyDrawer
     {
-        private Dictionary<int, string> _areaNameByIndex;
-        
+        private List<KeyValuePair<int, string>> _areaNameByIndex = new List<KeyValuePair<int, string>>();
+
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
             if (fieldInfo.GetReturnType() != typeof(int))
@@ -22,32 +23,68 @@ namespace Rhinox.GUIUtils.Editor
                 return;
             }
 
-            if (((NavMeshAreaAttribute) attribute).IsMask)
+            //this can props be optimized by caching the values, but
+            //If the navmesh area list change, the cache has to be update,
+            //and i don't know if there is an event for when that updates
+            var options = GameObjectUtility.GetNavMeshAreaNames();
+            _areaNameByIndex = options.Select(x => new KeyValuePair<int, string>(NavMesh.GetAreaFromName(x), x)).ToList();
+
+            if (((NavMeshAreaAttribute)attribute).IsMask)
             {
-                var options = GameObjectUtility.GetNavMeshAreaNames();
-                property.intValue = EditorGUI.MaskField(position, label, property.intValue, options);
-            }
-            else
-            {
-                var options = GameObjectUtility.GetNavMeshAreaNames();
-                if (_areaNameByIndex == null || options.Any(x => !_areaNameByIndex.ContainsValue(x)))
+                int convertedMask = 0;
+                if (property.intValue != 0)
                 {
-                    _areaNameByIndex = new Dictionary<int, string>();
-                    foreach (var option in options)
+                    for (int index = 0; index < 32; index++)
                     {
-                        _areaNameByIndex.Add(NavMesh.GetAreaFromName(option), option);
+                        if ((property.intValue >> index & 1) == 1)
+                        {
+                            convertedMask |= 1 << _areaNameByIndex.FindIndex(x => x.Key == index);
+
+                            property.intValue -= 1 << index;
+                            if (property.intValue == 0)
+                                break;
+                        }
                     }
                 }
 
-                if (!_areaNameByIndex.ContainsKey(property.intValue))
+                convertedMask = EditorGUI.MaskField(position, label, convertedMask, options);
+
+                property.intValue = 0;
+                if (convertedMask != 0)
+                {
+                    for (int index = 0; index < _areaNameByIndex.Count; index++)
+                    {
+                        if ((convertedMask >> index & 1) == 1)
+                        {
+                            property.intValue |= 1 << _areaNameByIndex[index].Key;
+
+                            convertedMask -= 1 << index;
+                            if (convertedMask == 0)
+                                break;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                var result = _areaNameByIndex.FirstOrDefault(x => x.Key == property.intValue);
+                string dropDownText;
+                if (!result.IsDefault())
+                {
+                    dropDownText = result.Value;
+                }
+                else
+                {
+                    dropDownText = "<Select a value>";
                     property.intValue = -1;
+                }
 
                 EditorGUILayout.BeginHorizontal();
                 var controlRect = EditorGUI.PrefixLabel(position, label);
-                if (EditorGUI.DropdownButton(controlRect, GUIContentHelper.TempContent(property.intValue == -1 ? "<Select a value>" : _areaNameByIndex[property.intValue]), FocusType.Passive, EditorStyles.miniPullDown))
+                if (EditorGUI.DropdownButton(controlRect, GUIContentHelper.TempContent(dropDownText), FocusType.Passive, EditorStyles.miniPullDown))
                 {
                     var menu = new GenericMenu();
-                    
+
                     foreach (var option in options)
                     {
                         menu.AddItem(new GUIContent(option), false, () =>

--- a/Assets/GUIUtils/Utils.meta
+++ b/Assets/GUIUtils/Utils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6fb8c6c674027774db2a66649d3b63b7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/GUIUtils/Utils/LayerUtils.cs
+++ b/Assets/GUIUtils/Utils/LayerUtils.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace Rhinox.GUIUtils.Utils
+{
+    public static class LayerUtils
+    {
+        public static string[] GetLayerNames()
+        {
+            return Enumerable.Range(0, 32)
+                             .Select(index => LayerMask.LayerToName(index))
+                             .Where(l => !string.IsNullOrEmpty(l))
+                             .ToArray();
+        }
+    }
+}

--- a/Assets/GUIUtils/Utils/LayerUtils.cs
+++ b/Assets/GUIUtils/Utils/LayerUtils.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using UnityEngine;
 
 namespace Rhinox.GUIUtils.Utils
@@ -9,6 +7,7 @@ namespace Rhinox.GUIUtils.Utils
     {
         public static string[] GetLayerNames()
         {
+            //there are only 32 layer fields in Unity
             return Enumerable.Range(0, 32)
                              .Select(index => LayerMask.LayerToName(index))
                              .Where(l => !string.IsNullOrEmpty(l))

--- a/Assets/GUIUtils/Utils/LayerUtils.cs.meta
+++ b/Assets/GUIUtils/Utils/LayerUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3d22b36910a0eb546a9da409af1eb00d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/GUIUtils/package.json
+++ b/Assets/GUIUtils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.rhinox.open.guiutils",
   "displayName": "GUIUtils - Editor Graphical UI Extensions",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "unity": "2019.4",
   "description": "GUI Utils for Unity projects, mostly Editor extensions. (Optional Odin extensions)",
   "keywords": [

--- a/Assets/Tests/AttributeTester.cs
+++ b/Assets/Tests/AttributeTester.cs
@@ -9,6 +9,27 @@ public class AttributeTester : MonoBehaviour
 {
     public SerializableType Type;
 
+    [Header("Layer")]
     [Layer]
-    public int Layer;
+    public int Layer = 0;
+
+    [Layer(true)]
+    public int MaskLayer = 0;
+
+    [Header("Navmesh")]
+
+    [NavMeshArea]
+    public int NavMeshArea = 0;
+
+    [NavMeshArea(true)]
+    public int MaskNavMeshArea = 0;
+
+    [ContextMenu("Print Values")]
+    public void PrintValues()
+    {
+        Debug.Log($"Layer: {Layer}");
+        Debug.Log($"MaskLayer: {MaskLayer}");
+        Debug.Log($"NavMeshArea: {NavMeshArea}");
+        Debug.Log($"MaskNavMeshArea: {MaskNavMeshArea}");
+    }
 }

--- a/Assets/Tests/AttributeTester.cs
+++ b/Assets/Tests/AttributeTester.cs
@@ -1,8 +1,5 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using Rhinox.GUIUtils.Attributes;
+﻿using Rhinox.GUIUtils.Attributes;
 using Rhinox.Lightspeed;
-using Sirenix.OdinInspector;
 using UnityEngine;
 
 public class AttributeTester : MonoBehaviour

--- a/Assets/Tests/EditorTest.cs
+++ b/Assets/Tests/EditorTest.cs
@@ -52,7 +52,8 @@ public class EditorTest : MonoBehaviour
     public Shader AlsoAShader;
 
     public Shader Shader;
-    public ShaderParameterType Type;
+    //public ShaderParameterType Type;
+
 
     [ShaderParameterSelector(nameof(Shader), nameof(Type))]
     public string ShaderParam;

--- a/Assets/Tests/Scenes/test.unity
+++ b/Assets/Tests/Scenes/test.unity
@@ -154,7 +154,10 @@ MonoBehaviour:
     _assemblyName: 
     _assemblyQualifiedName: 
     _name: 
-  Layer: 5
+  Layer: 9
+  MaskLayer: 64
+  NavMeshArea: 4
+  MaskNavMeshArea: 16
 --- !u!4 &655071756
 Transform:
   m_ObjectHideFlags: 0

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -13,7 +13,7 @@
     "com.rhinox.open.lightspeed": "1.6.0",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.ide.rider": "1.2.1",
-    "com.unity.ide.visualstudio": "2.0.11",
+    "com.unity.ide.visualstudio": "2.0.18",
     "com.unity.ide.vscode": "1.2.3",
     "com.unity.test-framework": "1.1.27",
     "com.unity.textmeshpro": "2.1.4",

--- a/ProjectSettings/NavMeshAreas.asset
+++ b/ProjectSettings/NavMeshAreas.asset
@@ -11,7 +11,21 @@ NavMeshProjectSettings:
     cost: 1
   - name: Jump
     cost: 2
+  - name: Teleport
+    cost: 1
+  - name: NoTeleport
+    cost: 1
+  - name: Water
+    cost: 1
   - name: 
+    cost: 1
+  - name: 
+    cost: 1
+  - name: 
+    cost: 1
+  - name: 
+    cost: 1
+  - name: sjdbfjksdb
     cost: 1
   - name: 
     cost: 1
@@ -29,21 +43,7 @@ NavMeshProjectSettings:
     cost: 1
   - name: 
     cost: 1
-  - name: 
-    cost: 1
-  - name: 
-    cost: 1
-  - name: 
-    cost: 1
-  - name: 
-    cost: 1
-  - name: 
-    cost: 1
-  - name: 
-    cost: 1
-  - name: 
-    cost: 1
-  - name: 
+  - name: RaNdOm ArEA
     cost: 1
   - name: 
     cost: 1

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -13,8 +13,8 @@ TagManager:
   - UI
   - 
   - 
-  - 
-  - 
+  - Butllets
+  - Enemies
   - 
   - 
   - 


### PR DESCRIPTION
I tried to add the requested feature #44,  
while also fixing a bug in the LayerAttributeDrawer.

 ### Added
- LayerUtils.GetLayerNames() to give all layernames that aren't null.

### Modified
- LayerAttribute to have IsMask boolean.
- LayerAttributeDrawer to now work with this new boolean.

### Fixed
- NavMeshLayerAttributeDrawer to now give correct mask value if you skip n-amount of navmesharea names inside the list of 32 navmesh names.
