### PR TITLE
v2.12.0

### DIFF
--- a/Assets/GUIUtils/Attributes/IconPickerAttribute.cs
+++ b/Assets/GUIUtils/Attributes/IconPickerAttribute.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace Rhinox.GUIUtils.Attributes
+{
+    public class IconPickerAttribute : PropertyAttribute
+    {
+        
+    }
+}

--- a/Assets/GUIUtils/Attributes/IconPickerAttribute.cs.meta
+++ b/Assets/GUIUtils/Attributes/IconPickerAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d52024c5496e4948972a3912c3eabe56
+timeCreated: 1687851182

--- a/Assets/GUIUtils/Editor/Drawers/BasePickerPropertyDrawer.cs
+++ b/Assets/GUIUtils/Editor/Drawers/BasePickerPropertyDrawer.cs
@@ -1,0 +1,124 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Rhinox.Lightspeed;
+using UnityEditor;
+using UnityEngine;
+
+namespace Rhinox.GUIUtils.Editor
+{
+    public abstract class BasePickerPropertyDrawer<TField, TPicker> : BasePickerPropertyDrawer<TField>
+    {
+        protected override DrawerData CreateData(GenericHostInfo info)
+        {
+            var data = new DrawerData
+            {
+                Info = info,
+                Picker = null,
+                ActiveContent = new GUIContent()
+            };
+
+            var value = info.GetSmartValue<TField>();
+            if (value != null)
+            {
+                data.ActiveContent.text = GetNameForSelection(value);
+            }
+            return data;
+        }
+
+        protected override void OnOptionSelected(object selection, string selectionText, DrawerData data)
+        {
+            TPicker pickerVal = (TPicker) selection;
+            var val = GetValueForSelection(pickerVal);
+            base.OnOptionSelected(val, selectionText, data);
+        }
+
+        protected sealed override string GetNameForSelection(object selection)
+        {
+            if (selection == null)
+                return NULL_STRING;
+            TPicker pickerVal;
+            if (selection is TField fieldVal)
+                pickerVal = ReverseLookup(fieldVal);    
+            else
+                pickerVal = (TPicker) selection;
+            if (pickerVal == null)
+                return NULL_STRING;
+            return this.GetNameForSelection(pickerVal);
+        }
+
+        protected abstract TPicker ReverseLookup(TField fieldVal);
+
+        protected abstract string GetNameForSelection(TPicker pickerVal);
+
+        protected abstract TField GetValueForSelection(TPicker pickerVal);
+    }
+
+    public abstract class BasePickerPropertyDrawer<T> : BasePropertyDrawer<T, BasePickerPropertyDrawer<T>.DrawerData>
+    {
+        protected const string NULL_STRING = "<None>";
+        
+        public class DrawerData
+        {
+            public GenericHostInfo Info;
+            public BasePicker Picker;
+            public GUIContent ActiveContent;
+        }
+        
+        private GUIContent _noneContent;
+
+        protected override DrawerData CreateData(GenericHostInfo info)
+        {
+            var data = new DrawerData
+            {
+                Info = info,
+                Picker = null,
+                ActiveContent = new GUIContent()
+            };
+
+            var value = info.GetSmartValue<T>();
+            if (value != null)
+            {
+                data.ActiveContent.text = GetNameForSelection(value);
+            }
+            return data;
+        }
+
+        protected override GenericHostInfo GetHostInfo(DrawerData data) => data.Info;
+        protected override void OnInitialize()
+        {
+            base.OnInitialize();
+
+            _noneContent = new GUIContent(NULL_STRING);
+        }
+
+        protected override void DrawProperty(Rect position, ref DrawerData data, GUIContent label)
+        {
+            var dropdownRect = EditorGUI.PrefixLabel(position, label);
+            
+            var content = SmartValue == null ? _noneContent : data.ActiveContent;
+            
+            if (EditorGUI.DropdownButton(dropdownRect, content, FocusType.Keyboard))
+                DoPickerDropdown(position, data);
+        }
+
+        protected virtual void DoPickerDropdown(Rect position, DrawerData data)
+        {
+            if (data.Picker == null)
+            {
+                data.Picker = BuildPicker(data);
+                data.Picker.OptionSelectedGeneric += x => OnOptionSelected(x, GetNameForSelection(x), data);
+            }
+            data.Picker.Show(position);
+        }
+
+        protected abstract BasePicker BuildPicker(DrawerData data);
+
+        protected virtual void OnOptionSelected(object selection, string selectionText, DrawerData data)
+        {
+            data.Info.SetValue(selection);
+            data.ActiveContent.text = selectionText;
+        }
+
+        protected abstract string GetNameForSelection(object selection);
+    }
+}

--- a/Assets/GUIUtils/Editor/Drawers/BasePickerPropertyDrawer.cs.meta
+++ b/Assets/GUIUtils/Editor/Drawers/BasePickerPropertyDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 33c95f205a454c6eb20b036fc5e29d9a
+timeCreated: 1687856383

--- a/Assets/GUIUtils/Editor/Drawers/BasePropertyDrawer.cs
+++ b/Assets/GUIUtils/Editor/Drawers/BasePropertyDrawer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Rhinox.Lightspeed;
+using Rhinox.Lightspeed.Reflection;
 using UnityEditor;
 using UnityEditor.Graphs;
 using UnityEngine;
@@ -101,6 +102,11 @@ namespace Rhinox.GUIUtils.Editor
 
         protected sealed override void DrawProperty(Rect position, GUIContent label)
         {
+            if (!HostInfo.GetReturnType().InheritsFrom(typeof(T)))
+            {
+                CallInnerDrawer(position, label);
+                return;
+            }
             DrawProperty(position, ref _activeData, label);
         }
 

--- a/Assets/GUIUtils/Editor/Drawers/IconPickerDrawer.cs
+++ b/Assets/GUIUtils/Editor/Drawers/IconPickerDrawer.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Rhinox.GUIUtils.Attributes;
+using UnityEditor;
+using UnityEngine;
+
+namespace Rhinox.GUIUtils.Editor
+{
+    [CustomPropertyDrawer(typeof(IconPickerAttribute))]
+    public class IconPickerDrawer : BasePickerPropertyDrawer<Texture, UnityIcon>
+    {
+        protected override BasePicker BuildPicker(DrawerData data)
+        {
+            var icons = new List<UnityIcon>();
+            UnityIconFinder.FindIcons(ref icons);
+
+            var typedCollection = new TypedFilteredCollection<UnityIcon>(
+                icons,
+                x => x.Name,
+                x => x.Origin,
+                x => x.Icon
+            );
+            return new SimplePicker<UnityIcon>(typedCollection);
+        }
+
+        protected override UnityIcon ReverseLookup(Texture fieldVal)
+        {
+            var icons = new List<UnityIcon>();
+            UnityIconFinder.FindIcons(ref icons);
+            return icons.FirstOrDefault(x => x.Icon == fieldVal);
+        }
+
+        protected override string GetNameForSelection(UnityIcon pickerVal) => pickerVal.Name;
+
+        protected override Texture GetValueForSelection(UnityIcon pickerVal) => pickerVal.Icon;
+    }
+}

--- a/Assets/GUIUtils/Editor/Drawers/IconPickerDrawer.cs.meta
+++ b/Assets/GUIUtils/Editor/Drawers/IconPickerDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2fc5f068f0ad432893107a9c3da0a286
+timeCreated: 1687851252

--- a/Assets/GUIUtils/Editor/Editors/CustomSmartEditor.cs
+++ b/Assets/GUIUtils/Editor/Editors/CustomSmartEditor.cs
@@ -3,12 +3,13 @@ using Rhinox.GUIUtils.Attributes;
 using Rhinox.Lightspeed.Reflection;
 using UnityEditor;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace Rhinox.GUIUtils.Editor
 {
-    [CustomEditor(typeof(MonoBehaviour), true)]
+    [CustomEditor(typeof(Object), true)]
     [CanEditMultipleObjects]
-    public class CustomSmartEditor : BaseEditor<MonoBehaviour>
+    public class CustomSmartEditor : BaseEditor<Object>
     {
         private DrawablePropertyView _propertyView;
         

--- a/Assets/GUIUtils/Editor/Extensions/SerializedObjectExtensions.cs
+++ b/Assets/GUIUtils/Editor/Extensions/SerializedObjectExtensions.cs
@@ -457,5 +457,32 @@ namespace Rhinox.GUIUtils.Editor
             warning = null;
             return false;
         }
+        
+        public static SerializedProperty FindParentProperty(this SerializedProperty serializedProperty)
+        {
+            var propertyPaths = serializedProperty.propertyPath.Split('.');
+            if (propertyPaths.Length <= 1)
+            {
+                return default;
+            }
+
+            var parentSerializedProperty = serializedProperty.serializedObject.FindProperty(propertyPaths.First());
+            for (var index = 1; index < propertyPaths.Length - 1; index++)
+            {
+                if (propertyPaths[index] == "Array" && propertyPaths.Length > index + 1 && Regex.IsMatch(propertyPaths[index + 1], "^data\\[\\d+\\]$"))
+                {
+                    var match = Regex.Match(propertyPaths[index + 1], "^data\\[(\\d+)\\]$");
+                    var arrayIndex = int.Parse(match.Groups[1].Value);
+                    parentSerializedProperty = parentSerializedProperty.GetArrayElementAtIndex(arrayIndex);
+                    index++;
+                }
+                else
+                {
+                    parentSerializedProperty = parentSerializedProperty.FindPropertyRelative(propertyPaths[index]);
+                }
+            }
+
+            return parentSerializedProperty;
+        }
     }
 }

--- a/Assets/GUIUtils/Editor/GUI/CustomEditorGUI.cs
+++ b/Assets/GUIUtils/Editor/GUI/CustomEditorGUI.cs
@@ -404,7 +404,7 @@ namespace Rhinox.GUIUtils.Editor
         private static float slideRectSensitivity = 0.0f;
         private static float slideDeltaBuffer;
 
-        public static int SlideRectInt(Rect rect, int id, int value)
+        public static int TrackMouseDragForIntegerChange(Rect rect, int id, int value)
         {
             if (!GUI.enabled)
                 return value;

--- a/Assets/GUIUtils/Editor/GUI/CustomEditorGUI.cs
+++ b/Assets/GUIUtils/Editor/GUI/CustomEditorGUI.cs
@@ -56,6 +56,15 @@ namespace Rhinox.GUIUtils.Editor
             return null;
         }
 
+        public static float ContextWidth()
+        {
+            var guiViewType = typeof(UnityEditor.EditorGUIUtility);
+            var getProp = guiViewType.GetProperty("contextWidth", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            if (getProp != null)
+                return (float)getProp.GetValue(null);
+            return 0.0f;
+        }
+
         public static Rect GetTopLevelLayoutRect()
         {
             var layoutUtilType = typeof(UnityEngine.GUILayoutUtility);

--- a/Assets/GUIUtils/Editor/GUI/Data/List/BetterReorderableList.cs
+++ b/Assets/GUIUtils/Editor/GUI/Data/List/BetterReorderableList.cs
@@ -274,10 +274,18 @@ namespace Rhinox.GUIUtils.Editor
             Rect = rect;
 
             Rect headerRect = DisplayHeader ? new Rect(rect.x, rect.y, rect.width, this.headerHeight) : new Rect(rect.x, rect.y, rect.width, 0.0f);
-            Rect listRect = new Rect(rect.x, headerRect.y + headerRect.height, rect.width, this.GetListElementHeight());
-            Rect footerRect = new Rect(rect.x, listRect.y + listRect.height, rect.width, this.footerHeight);
+            Rect footerRect;
             this.DoListHeader(headerRect, label);
-            this.DoListElements(listRect);
+            if (!Collapsible || Expanded)
+            {
+                Rect listRect = new Rect(rect.x, headerRect.y + headerRect.height, rect.width, this.GetListElementHeight());
+                this.DoListElements(listRect);
+                footerRect = new Rect(rect.x, listRect.y + listRect.height, rect.width, this.footerHeight);
+            }
+            else
+            {
+                footerRect = new Rect(rect.x, headerRect.y + headerRect.height, rect.width, this.footerHeight);
+            }
             this.DoListFooter(footerRect);
         }
 

--- a/Assets/GUIUtils/Editor/GUI/Data/UnityIcon.cs
+++ b/Assets/GUIUtils/Editor/GUI/Data/UnityIcon.cs
@@ -188,11 +188,11 @@ namespace Rhinox.GUIUtils.Editor
 #endif
         }
 
-        public static Texture Find(string name)
+        public static Texture2D Find(string name)
         {
             var odinIcons = GetAll();
             if (odinIcons.ContainsKey(name))
-                return odinIcons[name];
+                return odinIcons[name] as Texture2D;
             return null;
         }
     }
@@ -275,7 +275,7 @@ namespace Rhinox.GUIUtils.Editor
 
         public static Texture2D AssetIcon(string name, string ext = ".png") => AssetUnityIcon.Find(name, ext);
 
-        public static Texture OdinIcon(string name) => OdinUnityIcon.Find(name);
+        public static Texture2D OdinIcon(string name) => OdinUnityIcon.Find(name);
     }
 
     public static class UnityIconFinder

--- a/Assets/GUIUtils/Editor/GUI/Data/UnityIcon.cs
+++ b/Assets/GUIUtils/Editor/GUI/Data/UnityIcon.cs
@@ -9,7 +9,6 @@ using Sirenix.Utilities.Editor;
 #endif
 using UnityEditor;
 using UnityEngine;
-
 using Object = UnityEngine.Object;
 using ObjectFieldAlignment = Sirenix.OdinInspector.ObjectFieldAlignment;
 
@@ -18,9 +17,12 @@ namespace Rhinox.GUIUtils.Editor
     public class InternalUnityIcon : UnityIcon
     {
         public override string TextureUsage => $"UnityIcon.InternalIcon(\"{GetBestName()}\")";
-        
-        [HorizontalGroup("Variants"), ReadOnly, LabelText("Light/Dark (d_)"), ToggleLeft] public bool HasLightDarkVariants;
-        [HorizontalGroup("Variants"), ReadOnly, LabelText("HighRes (@2x)"), ToggleLeft] public bool HasHighResVariants;
+
+        [HorizontalGroup("Variants"), ReadOnly, LabelText("Light/Dark (d_)"), ToggleLeft]
+        public bool HasLightDarkVariants;
+
+        [HorizontalGroup("Variants"), ReadOnly, LabelText("HighRes (@2x)"), ToggleLeft]
+        public bool HasHighResVariants;
 
         private string GetBestName()
         {
@@ -43,7 +45,7 @@ namespace Rhinox.GUIUtils.Editor
 
             return EditorUtility.IsPersistent(tex);
         }
-        
+
         public static Texture2D[] GetAll()
         {
             // FindObjectsOfTypeAll only does loaded; so load all
@@ -68,17 +70,18 @@ namespace Rhinox.GUIUtils.Editor
     {
         public string Extension { get; set; }
 
-        public override string TextureUsage => $"UnityIcon.AssetIcon(\"{Name}{(Extension == ".png" ? "" : $", \"{Extension}\"")}\")";
-        
+        public override string TextureUsage =>
+            $"UnityIcon.AssetIcon(\"{Name}{(Extension == ".png" ? "" : $", \"{Extension}\"")}\")";
+
         /// ================================================================================================================
         /// STATIC
-        public static readonly string[] IconFolders = new []
+        public static readonly string[] IconFolders = new[]
         {
             "Assets/Editor/Icons",
             "Assets/Icons",
-            
+
             "Assets/Plugins/Editor/Icons",
-            
+
             "Assets/GUIUtils/Icons",
             "Packages/com.rhinox.open.guiutils/Icons"
         };
@@ -91,19 +94,19 @@ namespace Rhinox.GUIUtils.Editor
             foreach (var folder in AssetUnityIcon.IconFolders)
             {
                 var path = FormatAssetsPath(folder);
-                
+
                 if (!AssetDatabase.IsValidFolder(path))
                     continue;
-                
+
                 var iconAsset = AssetDatabase.LoadAssetAtPath<Texture2D>(Path.Combine(path, name + ext));
-                
+
                 if (iconAsset)
                     return iconAsset;
             }
 
             return null;
         }
-        
+
         public static string[] GetAll()
         {
             var folders = IconFolders
@@ -112,12 +115,12 @@ namespace Rhinox.GUIUtils.Editor
                 .ToArray();
 
             if (!folders.Any()) return Array.Empty<string>();
-            
+
             return AssetDatabase.FindAssets("t:Texture", searchInFolders: folders)
                 .Select(AssetDatabase.GUIDToAssetPath)
                 .ToArray();
         }
-        
+
         public static string FormatAssetsPath(string assetFolderPath)
         {
             assetFolderPath = (assetFolderPath ?? "")
@@ -144,6 +147,7 @@ namespace Rhinox.GUIUtils.Editor
 
         private static MethodInfo _getIconForType;
         private static readonly object[] _arr = new object[1];
+
         private static Texture2D GetIconForObject(UnityEngine.Object o)
         {
             // TODO: made public in 2021.2
@@ -151,18 +155,19 @@ namespace Rhinox.GUIUtils.Editor
             {
                 // EditorGUIUtility.GetIconForObject
                 var type = typeof(UnityEditor.Editor).Assembly.GetType("UnityEditor.EditorGUIUtility");
-                _getIconForType = type.GetMethod("GetIconForObject", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+                _getIconForType = type.GetMethod("GetIconForObject",
+                    BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
             }
 
             _arr[0] = o;
-            return  (Texture2D) _getIconForType.Invoke(null, _arr);
+            return (Texture2D) _getIconForType.Invoke(null, _arr);
         }
     }
 
     public class OdinUnityIcon : UnityIcon
     {
         public override string TextureUsage => "EditorIcons.{Name}.Active";
-        
+
         /// ================================================================================================================
         /// STATIC
         public static Dictionary<string, Texture> GetAll()
@@ -182,9 +187,17 @@ namespace Rhinox.GUIUtils.Editor
             return new Dictionary<string, Texture>();
 #endif
         }
+
+        public static Texture Find(string name)
+        {
+            var odinIcons = GetAll();
+            if (odinIcons.ContainsKey(name))
+                return odinIcons[name];
+            return null;
+        }
     }
-    
-     /// <summary>
+
+    /// <summary>
     /// A struct used for displaying all icons used in UnityIconsViewer
     /// Also used to find corresponding textures
     /// </summary>
@@ -192,19 +205,15 @@ namespace Rhinox.GUIUtils.Editor
     {
         /// ================================================================================================================
         /// EDITOR DISPLAY
-        [ReadOnly, HideLabel, Title("Info")]
-        [HorizontalGroup("H"), VerticalGroup("H/Left", 0)]
+        [ReadOnly, HideLabel, Title("Info")] [HorizontalGroup("H"), VerticalGroup("H/Left", 0)]
         public string Name;
 
-        [ReadOnly]
-        [VerticalGroup("H/Left", 0)]
+        [ReadOnly] [VerticalGroup("H/Left", 0)]
         public string Origin;
-        
-        [HideLabel, PreviewField(70, ObjectFieldAlignment.Right)]
-        [HorizontalGroup("H/Right", 70, 1)]
-        [ReadOnly]
+
+        [HideLabel, PreviewField(70, ObjectFieldAlignment.Right)] [HorizontalGroup("H/Right", 70, 1)] [ReadOnly]
         public Texture Icon;
-        
+
         public abstract string TextureUsage { get; }
 
         [PropertySpace(10)]
@@ -256,7 +265,7 @@ namespace Rhinox.GUIUtils.Editor
             var iconContent = EditorGUIUtility.IconContent(name);
             return iconContent?.image as Texture2D;
         }
-        
+
         public static Texture2D ScriptIcon(string name)
         {
             // There is a proper method but it is internal so...
@@ -266,7 +275,125 @@ namespace Rhinox.GUIUtils.Editor
 
         public static Texture2D AssetIcon(string name, string ext = ".png") => AssetUnityIcon.Find(name, ext);
 
-        /// ================================================================================================================
-        /// ICON LISTS
+        public static Texture OdinIcon(string name) => OdinUnityIcon.Find(name);
+    }
+
+    public static class UnityIconFinder
+    {
+        public static void FindIcons(ref List<UnityIcon> icons)
+        {
+            icons.Clear();
+
+            // Internal icons
+            var textures = InternalUnityIcon.GetAll();
+            foreach (var group in textures.GroupBy(x => InternalUnityIcon.TrimmedName(x)))
+            {
+                if (group.Count() == 1)
+                {
+                    var tex = group.First();
+                    icons.Add(new InternalUnityIcon
+                    {
+                        Icon = tex,
+                        Name = tex.name,
+                        Origin = "Internal",
+                    });
+                }
+                else
+                {
+                    Texture2D darkTex = null, lightTex = null, highresDarkTex = null, highresLightTex = null;
+                    foreach (var texture in group)
+                    {
+                        if (texture.name.EndsWith("@2x"))
+                        {
+                            if (texture.name.StartsWith("d_"))
+                                highresDarkTex = texture;
+                            else
+                                highresLightTex = texture;
+                        }
+                        else
+                        {
+                            if (texture.name.StartsWith("d_"))
+                                darkTex = texture;
+                            else
+                                lightTex = texture;
+                        }
+                    }
+
+                    Texture2D tex;
+
+                    if (EditorGUIUtility.isProSkin)
+                        tex = highresDarkTex ?? darkTex ?? highresLightTex ?? lightTex;
+                    else
+                        tex = highresLightTex ?? lightTex ?? highresDarkTex ?? darkTex;
+
+                    bool hasDarkLightVariants = darkTex && lightTex;
+                    bool hasHighResVariants = highresDarkTex || highresLightTex;
+
+                    icons.Add(new InternalUnityIcon
+                    {
+                        Icon = tex,
+                        Name = hasDarkLightVariants ? lightTex.name : tex.name,
+                        HasLightDarkVariants = hasDarkLightVariants,
+                        HasHighResVariants = hasHighResVariants,
+                        Origin = "Internal",
+                    });
+                }
+            }
+
+            // Class icons
+            textures = ScriptUnityIcon.GetAll();
+            foreach (var tex in textures)
+            {
+                icons.Add(new ScriptUnityIcon
+                {
+                    Icon = tex,
+                    Name = tex.name,
+                    Origin = "Script"
+                });
+            }
+
+            // Odin icons
+            var odinIcons = OdinUnityIcon.GetAll();
+            foreach (var pair in odinIcons)
+            {
+                icons.Add(new OdinUnityIcon
+                {
+                    Icon = pair.Value,
+                    Name = pair.Key,
+                    Origin = "Odin",
+                });
+            }
+
+            // resources icons
+            icons.AddRange(GetAssetIcons(AssetUnityIcon.GetAll()));
+
+            icons.Sort();
+            Resources.UnloadUnusedAssets();
+            GC.Collect();
+        }
+
+
+        private static List<UnityIcon> GetAssetIcons(string[] iconPaths)
+        {
+            var icons = new List<UnityIcon>();
+            foreach (var path in iconPaths)
+            {
+                var tex = AssetDatabase.LoadAssetAtPath<Texture>(path);
+                if (tex == null) continue;
+
+                var name = Path.GetFileNameWithoutExtension(path);
+                var ext = Path.GetExtension(path);
+
+                icons.Add(new AssetUnityIcon
+                {
+                    Name = name,
+                    Extension = ext,
+                    Icon = tex,
+                    Origin = "Asset Texture",
+                });
+            }
+
+            return icons;
+        }
     }
 }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/AttributeParser.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/AttributeParser.cs
@@ -13,7 +13,7 @@ namespace Rhinox.GUIUtils.Editor
             var orderAttr = memberInfo.GetCustomAttribute<PropertyOrderAttribute>();
             if (orderAttr != null)
             {
-                order = orderAttr.Order;
+                order = (int)orderAttr.Order;
                 return true;
             }
             

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/GroupingHelper.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/GroupingHelper.cs
@@ -15,11 +15,11 @@ namespace Rhinox.GUIUtils.Editor
             switch (groupingAttr)
             {
                 case ButtonGroupAttribute buttonGroupAttribute:
-                    return new ButtonGroupDrawable(parent, groupingAttr.GroupID, groupingAttr.Order);
+                    return new ButtonGroupDrawable(parent, groupingAttr.GroupID, (int)groupingAttr.Order);
                 case HorizontalGroupAttribute horizontalGroupAttribute:
-                    return new HorizontalGroupDrawable(parent, groupingAttr.GroupID, groupingAttr.Order);
+                    return new HorizontalGroupDrawable(parent, groupingAttr.GroupID, (int)groupingAttr.Order);
                 case TitleGroupAttribute titleGroupAttribute:
-                    return new TitleGroupDrawable(parent, groupingAttr.GroupID, groupingAttr.Order);
+                    return new TitleGroupDrawable(parent, groupingAttr.GroupID, (int)groupingAttr.Order);
                 case VerticalGroupAttribute verticalGroupAttribute:
                     return new VerticalGroupDrawable(parent, groupingAttr.GroupID, groupingAttr.Order);
                 case TabGroupAttribute tabGroupAttribute:

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/GroupingHelper.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/GroupingHelper.cs
@@ -16,12 +16,15 @@ namespace Rhinox.GUIUtils.Editor
             {
                 case ButtonGroupAttribute buttonGroupAttribute:
                     return new ButtonGroupDrawable(parent, groupingAttr.GroupID, groupingAttr.Order);
+                    return new ButtonGroupDrawable(parent, groupingAttr.GroupID, groupingAttr.Order);
                 case HorizontalGroupAttribute horizontalGroupAttribute:
                     return new HorizontalGroupDrawable(parent, groupingAttr.GroupID, groupingAttr.Order);
                 case TitleGroupAttribute titleGroupAttribute:
                     return new TitleGroupDrawable(parent, groupingAttr.GroupID, groupingAttr.Order);
                 case VerticalGroupAttribute verticalGroupAttribute:
                     return new VerticalGroupDrawable(parent, groupingAttr.GroupID, groupingAttr.Order);
+                case TabGroupAttribute tabGroupAttribute:
+                    return new TabGroupDrawable(parent, groupingAttr.GroupID, groupingAttr.Order);
                 default:
                     Debug.LogWarning($"Unimplemented Group type: {groupingAttr.GetType().Name}, falling back to FallbackGroup (layout: Vertical)...");
                     return new FallbackGroupDrawable(parent, groupingAttr.GroupID, groupingAttr.Order);

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/GroupingHelper.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/GroupingHelper.cs
@@ -16,7 +16,6 @@ namespace Rhinox.GUIUtils.Editor
             {
                 case ButtonGroupAttribute buttonGroupAttribute:
                     return new ButtonGroupDrawable(parent, groupingAttr.GroupID, groupingAttr.Order);
-                    return new ButtonGroupDrawable(parent, groupingAttr.GroupID, groupingAttr.Order);
                 case HorizontalGroupAttribute horizontalGroupAttribute:
                     return new HorizontalGroupDrawable(parent, groupingAttr.GroupID, groupingAttr.Order);
                 case TitleGroupAttribute titleGroupAttribute:

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/TabGroupDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/TabGroupDrawable.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.Linq;
+using Sirenix.OdinInspector;
+using UnityEditor;
+using UnityEngine;
+
+namespace Rhinox.GUIUtils.Editor
+{
+    public class TabGroupDrawable : BaseVerticalGroupDrawable<TabGroupAttribute>
+    {
+        private Dictionary<string, List<IOrderedDrawable>> _dic;
+        private List<string> _tabs;
+
+        public int _index = 0;
+        public TabGroupDrawable(GroupedDrawable parent, string groupID, float order) : base(parent, groupID, order)
+        {
+            _dic = new Dictionary<string, List<IOrderedDrawable>>();
+            _tabs = new List<string>();
+        }
+
+        protected override void ParseAttributeSmart(IOrderedDrawable child, TabGroupAttribute attr)
+        {
+            if (!_dic.ContainsKey(attr.TabName))
+            { 
+                _dic.Add(attr.TabName, new List<IOrderedDrawable>());
+                _tabs.Add(attr.TabName);
+            }
+            
+            _dic[attr.TabName].Add(child);
+            
+            
+        }
+
+        protected override void ParseAttributeSmart(TabGroupAttribute attr)
+        {
+           
+            
+        }
+
+        public override void Draw(GUIContent label)
+        {
+            var activeTab = _tabs[_index];
+            
+            if (_drawableMemberChildren == null)
+                return;
+
+            GUILayout.BeginVertical(CustomGUIStyles.Clean, GetLayoutOptions(_size));
+            // EditorGUILayout.BeginFadeGroup()
+            _index = GUILayout.Toolbar(_index, _tabs.ToArray());
+            
+            for (var i = 0; i < _drawableMemberChildren.Count; i++)
+            {
+                var childDrawable = _drawableMemberChildren[i];
+      
+                if (childDrawable == null || !childDrawable.IsVisible)
+                    continue;
+          
+                if (!_dic[activeTab].Contains(childDrawable)) continue;
+
+                childDrawable.Draw(childDrawable.Label);
+
+                if (_drawableMemberChildren.Count - 1 != i)
+                    GUILayout.Space(CustomGUIUtility.Padding); // padding
+            }
+
+            GUILayout.EndVertical();
+        }
+    }
+}

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/TabGroupDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/TabGroupDrawable.cs
@@ -27,8 +27,6 @@ namespace Rhinox.GUIUtils.Editor
             }
             
             _dic[attr.TabName].Add(child);
-            
-            
         }
 
         protected override void ParseAttributeSmart(TabGroupAttribute attr)
@@ -45,7 +43,7 @@ namespace Rhinox.GUIUtils.Editor
                 return;
 
             GUILayout.BeginVertical(CustomGUIStyles.Clean, GetLayoutOptions(_size));
-            // EditorGUILayout.BeginFadeGroup()
+            
             _index = GUILayout.Toolbar(_index, _tabs.ToArray());
             
             for (var i = 0; i < _drawableMemberChildren.Count; i++)
@@ -55,12 +53,13 @@ namespace Rhinox.GUIUtils.Editor
                 if (childDrawable == null || !childDrawable.IsVisible)
                     continue;
           
-                if (!_dic[activeTab].Contains(childDrawable)) continue;
+                if (!_dic[activeTab].Contains(childDrawable)) 
+                    continue;
 
                 childDrawable.Draw(childDrawable.Label);
 
-                if (_drawableMemberChildren.Count - 1 != i)
-                    GUILayout.Space(CustomGUIUtility.Padding); // padding
+                if (i < _drawableMemberChildren.Count - 1)
+                    GUILayout.Space(CustomGUIUtility.Padding); // padding while not the last element
             }
 
             GUILayout.EndVertical();

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/TabGroupDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/TabGroupDrawable.cs
@@ -9,13 +9,19 @@ namespace Rhinox.GUIUtils.Editor
     public class TabGroupDrawable : BaseVerticalGroupDrawable<TabGroupAttribute>
     {
         private Dictionary<string, List<IOrderedDrawable>> _dic;
-        private List<string> _tabs;
+        private List<TabGroupName> _tabs;
+
+        private class TabGroupName
+        {
+            public string TabID;
+            public IPropertyMemberHelper<string> TabNameHelper;
+        }
 
         public int _index = 0;
         public TabGroupDrawable(GroupedDrawable parent, string groupID, float order) : base(parent, groupID, order)
         {
             _dic = new Dictionary<string, List<IOrderedDrawable>>();
-            _tabs = new List<string>();
+            _tabs = new List<TabGroupName>();
         }
 
         protected override void ParseAttributeSmart(IOrderedDrawable child, TabGroupAttribute attr)
@@ -23,7 +29,12 @@ namespace Rhinox.GUIUtils.Editor
             if (!_dic.ContainsKey(attr.TabName))
             { 
                 _dic.Add(attr.TabName, new List<IOrderedDrawable>());
-                _tabs.Add(attr.TabName);
+                var memberHelper = MemberHelper.Create<string>(child.HostInfo, attr.TabName);
+                _tabs.Add(new TabGroupName()
+                {
+                    TabID = attr.TabName,
+                    TabNameHelper = memberHelper
+                });
             }
             
             _dic[attr.TabName].Add(child);
@@ -44,7 +55,7 @@ namespace Rhinox.GUIUtils.Editor
 
             GUILayout.BeginVertical(CustomGUIStyles.Clean, GetLayoutOptions(_size));
             
-            _index = GUILayout.Toolbar(_index, _tabs.ToArray());
+            _index = GUILayout.Toolbar(_index, _tabs.Select(x => x.TabNameHelper.GetSmartValue()).ToArray());
             
             for (var i = 0; i < _drawableMemberChildren.Count; i++)
             {
@@ -53,7 +64,7 @@ namespace Rhinox.GUIUtils.Editor
                 if (childDrawable == null || !childDrawable.IsVisible)
                     continue;
           
-                if (!_dic[activeTab].Contains(childDrawable)) 
+                if (!_dic[activeTab.TabID].Contains(childDrawable)) 
                     continue;
 
                 childDrawable.Draw(childDrawable.Label);

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Composite/TabGroupDrawable.cs.meta
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Composite/TabGroupDrawable.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3be553eec62742c8a29da2894d63ebd6
+timeCreated: 1686146874

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawableFactory.cs
@@ -207,6 +207,10 @@ namespace Rhinox.GUIUtils.Editor
                         }
                         else
                         {
+                            var instanceVal = hostInfo.GetValue();
+                            if (instanceVal == null)
+                                return new TypePickerDrawable(property);
+                            
                             var visibleFields = property.EnumerateEditorVisibleFields();
                             var verticalGroupDrawable = DrawableMembersForSerializedObject(hostInfo, visibleFields, 0);
                             

--- a/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/DrawablePropertyView.cs
@@ -106,7 +106,7 @@ namespace Rhinox.GUIUtils.Editor
                 _serializedObject.ApplyModifiedProperties();
         }
         
-        internal void RequestRepaint()
+        public void RequestRepaint()
         {
             RepaintRequested?.Invoke();
         }

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Members/Value/UnityObjectDrawableField.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Members/Value/UnityObjectDrawableField.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using Rhinox.Lightspeed.Reflection;
+using Sirenix.OdinInspector;
 using UnityEditor;
 using UnityEngine;
 using Object = System.Object;
@@ -12,7 +13,7 @@ namespace Rhinox.GUIUtils.Editor
 
         public UnityObjectDrawableField(GenericHostInfo hostInfo) : base(hostInfo)
         {
-            
+            AllowSceneObjects = hostInfo.GetReturnType().GetCustomAttribute<AssetsOnlyAttribute>() == null;
         }
         
         protected override UnityEngine.Object DrawValue(GUIContent label, UnityEngine.Object memberVal, params GUILayoutOption[] options)

--- a/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/TypePickerDrawable.cs
+++ b/Assets/GUIUtils/Editor/GUI/Drawables/Wrappers/TypePickerDrawable.cs
@@ -73,8 +73,9 @@ namespace Rhinox.GUIUtils.Editor
             var type = _hostInfo.GetReturnType(false);
             var options = ReflectionUtility.GetTypesInheritingFrom(type);
 
-            _typePicker = GenericPicker.Show(position, options);
+            _typePicker = new TypePicker(options);
             _typePicker.OptionSelected += SetManagedReference;
+            _typePicker.Show(position);
         }
 
         private void SetManagedReference(object data)

--- a/Assets/GUIUtils/Editor/Helpers/Containers/CustomMenuTree.cs
+++ b/Assets/GUIUtils/Editor/Helpers/Containers/CustomMenuTree.cs
@@ -643,9 +643,14 @@ namespace Rhinox.GUIUtils.Editor
                 _innerItem.DrawMenuItem(i);
             }
 
-            public void Update()
+            public void CheckForInteractions(bool multi)
             {
-                //_innerItem.
+                // NOP
+            }
+
+            public void ResetInteractionState()
+            {
+                // NOP
             }
 
             public void Deselect()

--- a/Assets/GUIUtils/Editor/Helpers/FilteredCollection.cs
+++ b/Assets/GUIUtils/Editor/Helpers/FilteredCollection.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace Rhinox.GUIUtils.Editor
 {
@@ -10,6 +11,7 @@ namespace Rhinox.GUIUtils.Editor
         public readonly int AmountOfOptions;
         public readonly List<object> FilteredValues = new List<object>();
         
+        // TODO: what is this doing here?
         public static FilteredCollection Create<T>(
             ICollection<T> options,
             Func<T, string> textSelector,
@@ -37,5 +39,11 @@ namespace Rhinox.GUIUtils.Editor
         protected abstract bool MatchesFilter(object o, string filter);
         public abstract string GetTextFor(object o);
         public abstract string GetSubTextFor(object o);
+        
+        public virtual bool TryGetIconFor(object o, out Texture icon)
+        {
+            icon = null;
+            return false;
+        }
     }
 }

--- a/Assets/GUIUtils/Editor/Helpers/HostInfo.cs
+++ b/Assets/GUIUtils/Editor/Helpers/HostInfo.cs
@@ -17,7 +17,11 @@ namespace Rhinox.GUIUtils.Editor
         
         public override object GetValue() => GetHost();
         public override Type GetReturnType(bool preferValueType = true) => HostType;
-        public override Attribute[] GetAttributes() => Array.Empty<Attribute>();
+
+        public override Attribute[] GetAttributes()
+        {
+            return GetReturnType().GetCustomAttributes();
+        }
     }
 
     public class ParameterHostInfo : GenericHostInfo

--- a/Assets/GUIUtils/Editor/Helpers/HostInfo.cs
+++ b/Assets/GUIUtils/Editor/Helpers/HostInfo.cs
@@ -124,6 +124,13 @@ namespace Rhinox.GUIUtils.Editor
             Root.ApplyModifiedProperties();
             base.Apply();
         }
+
+        protected override GenericHostInfo CreateChildHostInfo(MemberInfo member)
+        {
+            if (member is FieldInfo fieldInfo)
+                return new HostInfo(this, fieldInfo);
+            return base.CreateChildHostInfo(member);
+        }
     }
     
     public class GenericHostInfo
@@ -336,6 +343,43 @@ namespace Rhinox.GUIUtils.Editor
         public virtual void Apply()
         {
             
+        }
+
+        public bool TryGetChild(string name, out GenericHostInfo childHostInfo)
+        {
+            Type t = GetReturnType();
+            if (t == null)
+            {
+                childHostInfo = null;
+                return false;
+            }
+            
+            var members = t.GetMember(name);
+            if (members.Length > 1 || members.Length == 0)
+            {
+                childHostInfo = null;
+                return false;
+            }
+
+            childHostInfo = CreateChildHostInfo(members[0]);
+            return true;
+        }
+
+        public bool TryGetChild<T>(string name, out TypedHostInfoWrapper<T> childHostInfo)
+        {
+            if (TryGetChild(name, out var info))
+            {
+                childHostInfo = new TypedHostInfoWrapper<T>(info);
+                return true;
+            }
+
+            childHostInfo = null;
+            return false;
+        }
+
+        protected virtual GenericHostInfo CreateChildHostInfo(MemberInfo member)
+        {
+            return new GenericHostInfo(this, member);
         }
     }
 }

--- a/Assets/GUIUtils/Editor/Helpers/Pickers/BasePicker.cs
+++ b/Assets/GUIUtils/Editor/Helpers/Pickers/BasePicker.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using Rhinox.GUIUtils;
 using Rhinox.GUIUtils.Editor;
 using Rhinox.Lightspeed;
@@ -19,6 +21,8 @@ namespace Rhinox.GUIUtils.Editor
                 _listView.DisplayHeader = value < FilteredCollection.AmountOfOptions;
             }
         }
+        
+        public event Action<object> OptionSelectedGeneric;
 
         protected PageableReorderableList _listView;
         private const int DefaultItemsPerPage = 10;
@@ -30,6 +34,7 @@ namespace Rhinox.GUIUtils.Editor
         protected string _controlName = GUID.Generate().ToString();
 
         protected Vector2 _size;
+        private bool _supportsIcons;
 
         public void Show(Rect rect)
         {
@@ -40,6 +45,13 @@ namespace Rhinox.GUIUtils.Editor
         protected void InitData(FilteredCollection handler)
         {
             FilteredCollection = handler;
+            int count = 0;
+            foreach (var option in handler.Options)
+            {
+                if (handler.TryGetIconFor(option, out _))
+                    ++count;
+            }
+            _supportsIcons = count > 0;
 
             _listView = new PageableReorderableList(FilteredCollection.FilteredValues)
             {
@@ -66,6 +78,7 @@ namespace Rhinox.GUIUtils.Editor
         private void OnOptionSelected(BetterReorderableList list)
         {
             OnOptionSelected(list.SelectedItem);
+            OptionSelectedGeneric?.Invoke(list.SelectedItem);
             editorWindow.Close();
         }
 
@@ -87,8 +100,19 @@ namespace Rhinox.GUIUtils.Editor
             var style = CustomGUIStyles.MiniLabel;
             var width = style.CalcMaxWidth(subText);
 
-            GUI.Label(rect.AlignLeft(rect.width - width), text);
-            GUI.Label(rect.AlignRight(width), subText, style);
+            if (_supportsIcons)
+            {
+                FilteredCollection.TryGetIconFor(obj, out var icon);
+                rect.SplitX(0.2f * rect.width, rect.width - width, out Rect left, out Rect middle, out Rect right);
+                GUI.DrawTexture(left, icon, ScaleMode.ScaleToFit);
+                GUI.Label(middle, GUIContentHelper.TempContent(text));
+                GUI.Label(right, subText, style);
+            }
+            else
+            {
+                GUI.Label(rect.AlignLeft(rect.width - width), GUIContentHelper.TempContent(text));
+                GUI.Label(rect.AlignRight(width), subText, style);
+            }
         }
 
         protected void OnRepaintRequested()

--- a/Assets/GUIUtils/Editor/Helpers/Pickers/BasePicker.cs
+++ b/Assets/GUIUtils/Editor/Helpers/Pickers/BasePicker.cs
@@ -57,7 +57,8 @@ namespace Rhinox.GUIUtils.Editor
             {
                 Draggable = false,
                 DisplayAdd = false,
-                DisplayRemove = false
+                DisplayRemove = false,
+                Collapsible = false
             };
             _listView.onSelectCallback += OnOptionSelected;
             _listView.RepaintRequested += OnRepaintRequested;

--- a/Assets/GUIUtils/Editor/Helpers/Pickers/GenericPicker.cs
+++ b/Assets/GUIUtils/Editor/Helpers/Pickers/GenericPicker.cs
@@ -9,10 +9,12 @@ namespace Rhinox.GUIUtils.Editor
         public static SimplePicker<T> Show<T>(
             Rect rect,
             ICollection<T> options,
+            Action<T> callback,
             Func<T, string> textSelector = null,
             Func<T, string> subtextSelector = null)
         {
             var picker = new SimplePicker<T>(options, textSelector, subtextSelector);
+            picker.OptionSelected += callback;
             picker.Show(rect);
             return picker;
         }

--- a/Assets/GUIUtils/Editor/Helpers/Pickers/SimplePicker.cs
+++ b/Assets/GUIUtils/Editor/Helpers/Pickers/SimplePicker.cs
@@ -22,6 +22,11 @@ namespace Rhinox.GUIUtils.Editor
             InitData(filteredCollection);
         }
 
+        public SimplePicker(FilteredCollection collectionFilter)
+        {
+            InitData(collectionFilter);
+        }
+
         protected override void OnOptionSelected(object option)
         {
             OptionSelected?.Invoke((T) option);

--- a/Assets/GUIUtils/Editor/Helpers/TypedFilteredCollection.cs
+++ b/Assets/GUIUtils/Editor/Helpers/TypedFilteredCollection.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Rhinox.Lightspeed;
+using UnityEngine;
 
 namespace Rhinox.GUIUtils.Editor
 {
@@ -8,12 +9,14 @@ namespace Rhinox.GUIUtils.Editor
     {
         protected Func<T, string> _textSelector;
         protected Func<T, string> _subTextSelector;
-        
-        public TypedFilteredCollection(ICollection<T> options, Func<T, string> textSelector, Func<T, string> subTextSelector)
+        protected Func<T, Texture> _iconSelector;
+
+        public TypedFilteredCollection(ICollection<T> options, Func<T, string> textSelector, Func<T, string> subTextSelector, Func<T, Texture> iconSelector = null)
             : base(options, options.Count)
         {
             _textSelector = textSelector;
             _subTextSelector = subTextSelector;
+            _iconSelector = iconSelector;
         }
 
         protected override bool MatchesFilter(object value, string filter)
@@ -42,6 +45,18 @@ namespace Rhinox.GUIUtils.Editor
         {
             if (_subTextSelector == null) return null;
             return _subTextSelector.Invoke((T)o);
+        }
+
+        public override bool TryGetIconFor(object o, out Texture t)
+        {
+            if (_iconSelector == null)
+            {
+                t = null;
+                return false;
+            }
+            
+            t = _iconSelector.Invoke((T)o);
+            return true;
         }
     }
 }

--- a/Assets/GUIUtils/Editor/Helpers/TypedHostInfoWrapper.cs
+++ b/Assets/GUIUtils/Editor/Helpers/TypedHostInfoWrapper.cs
@@ -1,0 +1,17 @@
+﻿namespace Rhinox.GUIUtils.Editor
+{
+    public class TypedHostInfoWrapper<T>
+    {
+        public GenericHostInfo HostInfo { get;}
+
+        public T SmartValue {
+            get { return HostInfo.GetSmartValue<T>(); }
+            set { HostInfo.SetValue(value); }
+        }
+        
+        public TypedHostInfoWrapper(GenericHostInfo hostInfo)
+        {
+            HostInfo = hostInfo;
+        }
+    }
+}

--- a/Assets/GUIUtils/Editor/Helpers/TypedHostInfoWrapper.cs.meta
+++ b/Assets/GUIUtils/Editor/Helpers/TypedHostInfoWrapper.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6a4ad7382cba42b38eb371b0df5c5856
+timeCreated: 1694512306

--- a/Assets/GUIUtils/Editor/Windows/PagerWindow/PagerEditorWindow.cs
+++ b/Assets/GUIUtils/Editor/Windows/PagerWindow/PagerEditorWindow.cs
@@ -14,7 +14,7 @@ namespace Rhinox.GUIUtils.Editor
 {
     public abstract class PagerEditorWindow<T> :
 #if ODIN_INSPECTOR
-        OdinEditorWindow where T : OdinEditorWindow
+        OdinEditorWindow, IRepaintable where T : OdinEditorWindow
 #else
         CustomEditorWindow where T : CustomEditorWindow
 #endif
@@ -163,5 +163,12 @@ namespace Rhinox.GUIUtils.Editor
         {
             return _pager.EnumeratePages.Select(x => x.Value);
         }
+
+#if ODIN_INSPECTOR
+        public void RequestRepaint()
+        {
+            this.Repaint();
+        }
+#endif
     }
 }

--- a/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ShaderParameterSelectorAttributeDrawer.cs
+++ b/Assets/GUIUtils/Odin/Editor/Drawers/Attributes/ShaderParameterSelectorAttributeDrawer.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Rhinox.GUIUtils.Attributes;
+using Rhinox.Lightspeed;
 using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities;
 using Sirenix.Utilities.Editor;

--- a/Assets/GUIUtils/package.json
+++ b/Assets/GUIUtils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.rhinox.open.guiutils",
   "displayName": "GUIUtils - Editor Graphical UI Extensions",
-  "version": "2.11.3",
+  "version": "2.12.0",
   "unity": "2019.4",
   "description": "GUI Utils for Unity projects, mostly Editor extensions. (Optional Odin extensions)",
   "keywords": [
@@ -10,7 +10,7 @@
   ],
   "category": "Unity",
   "dependencies": {
-    "com.rhinox.open.lightspeed": "1.6.0"
+    "com.rhinox.open.lightspeed": "1.7.0"
   },
   "repository": {
     "type": "git",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -10,7 +10,7 @@
     }
   ],
   "dependencies": {
-    "com.rhinox.open.lightspeed": "1.6.0",
+    "com.rhinox.open.lightspeed": "1.7.0",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.ide.rider": "1.2.1",
     "com.unity.ide.visualstudio": "2.0.18",


### PR DESCRIPTION
### Added
- IconPickerAttribute: Creates a dropdown for Texture fields from the UnityIcon set, in a DrawablePropertyView context
- BasePickerPropertyDrawer: An override for dropdown value drawing for specific types
- BasePropertyDrawer.FindAttribute(<T>): Find attributes across the rendering hierachy of certain property (works with DrawablePropertyView in both Unity serialized and generic contexts)
- BasePropertyDrawer.OnUpdateActiveData: Callback for when the drawer changes drawn target
- SerializedObjectExtensions.FindParentProperty(SerializedProperty)
- CustomEditorGUI.ContextWidth (reflection from Unity internal property)
- CustomEditorGUI.ToolbarSearchField, CustomEditorGUI.TrackMouseDragForIntegerChange
- UnityIcon.OdinIcon (Odin only)
- UnityIconFinder: Static class to browse/search for icons
- TabGroupDrawable: Drawer for TabGroupAttribute
- TypedHostInfoWrapper<T>: Wraps a HostInfo object and exposed the type as generic T

### Modified
- CustomSmartEditor now works for ScriptableObjects as well as MonoBehaviours/Components
- DrawablePropertyView.Repaint switched from internal to public
- UnityObjectDrawableField: AllowSceneObjects properly handled for generic context
- FilteredCollection + BasePicker: Support for icons on entries
- HostInfo.CreateChildHostInfo: to browse deeper in the drawn property tree
- SimplePicker<T> changed API to include a callback lambda for selected options

### Fixed
- BasePropertyDrawer crashing on type of value being changed
- BetterReorderableList: Collapsible on Rect based rendering didn't hide elements
- Null reference handling for CreateDrawableForSerializedProperty 
- TypePickerDrawable: Dropdown callback not being called
- Compiler errors on CustomMenuTree with Odin Inspector
- RootHostInfo.GetAttributes was not implemented (returned empty array always)
- PagerEditorWindow fixed Repaint for Odin Inspector builds