### PR TITLE
v3.0.2

### DIFF
--- a/Assets/GUIUtils/Editor/AttributeProcessor/BaseAttributeProcessor.cs
+++ b/Assets/GUIUtils/Editor/AttributeProcessor/BaseAttributeProcessor.cs
@@ -2,24 +2,28 @@
 using System.Collections.Generic;
 using System.Reflection;
 
+
 namespace Rhinox.GUIUtils.Editor
 {
-    public abstract class BaseAttributeProcessor<T> : IAttributeProcessor
+    public abstract class BaseAttributeProcessor<T> :
 #if ODIN_INSPECTOR
-        , OdinAttributeProcessor<T>
+        Sirenix.OdinInspector.Editor.OdinAttributeProcessor<T>,
 #endif
+        IAttributeProcessor
     {
         public Type ManagedType => typeof(T);
-        
+
 #if ODIN_INSPECTOR
-        public override void ProcessSelfAttributes(InspectorProperty property, List<Attribute> attributes)
+        public override void ProcessSelfAttributes(Sirenix.OdinInspector.Editor.InspectorProperty property,
+            List<Attribute> attributes)
         {
             ProcessType(ref attributes);
         }
 #endif
 
 #if ODIN_INSPECTOR
-        public override void ProcessChildMemberAttributes(InspectorProperty parentProperty, MemberInfo member, List<Attribute> attributes)
+        public override void ProcessChildMemberAttributes(Sirenix.OdinInspector.Editor.InspectorProperty parentProperty,
+            MemberInfo member, List<Attribute> attributes)
         {
             ProcessMember(member, ref attributes);
         }
@@ -27,12 +31,10 @@ namespace Rhinox.GUIUtils.Editor
 
         public virtual void ProcessType(ref List<Attribute> attributes)
         {
-            
         }
 
         public virtual void ProcessMember(MemberInfo memberInfo, ref List<Attribute> attributes)
         {
-            
         }
     }
 }

--- a/Assets/GUIUtils/package.json
+++ b/Assets/GUIUtils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.rhinox.open.guiutils",
   "displayName": "GUIUtils - Editor Graphical UI Extensions",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "unity": "2019.4",
   "description": "GUI Utils for Unity projects, mostly Editor extensions. (Optional Odin extensions)",
   "keywords": [


### PR DESCRIPTION
###Fixed
- When using Odin inside BaseAttributeProcessor, the OdinAttributeProcessor namespace was not made explicit